### PR TITLE
Improvement/shuffle events

### DIFF
--- a/frontend/src/aspects/Conference/Attend/Room/Room.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Room.tsx
@@ -66,8 +66,7 @@ gql`
         itemId
         exhibitionId
         shufflePeriod {
-            id
-            name
+            ...ShufflePeriodData
         }
         item {
             id

--- a/frontend/src/aspects/Conference/Attend/Room/RoomContent.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/RoomContent.tsx
@@ -2,9 +2,7 @@ import {
     Alert,
     AlertIcon,
     Box,
-    Button,
     Center,
-    chakra,
     Heading,
     HStack,
     Tag,
@@ -22,11 +20,10 @@ import {
     Room_Mode_Enum,
 } from "../../../../generated/graphql";
 import { useRealTime } from "../../../Generic/useRealTime";
-import FAIcon from "../../../Icons/FAIcon";
+import { ShufflePeriodBox } from "../../../ShuffleRooms/WaitingPage";
 import useCurrentRegistrant from "../../useCurrentRegistrant";
 import { ItemElementsWrapper } from "../Content/ItemElements";
 import { ExhibitionLayoutWrapper } from "../Exhibition/ExhibitionLayout";
-import { SocialiseModalTab, useSocialiseModal } from "../Rooms/V2/SocialiseModal";
 import { RoomTitle } from "./RoomTitle";
 import { RoomSponsorContent } from "./Sponsor/RoomSponsorContent";
 import { VideoElementButton } from "./Video/VideoElementButton";
@@ -88,7 +85,6 @@ export function RoomContent({
     );
 
     const now5s = useRealTime(5000);
-    const socialiseModal = useSocialiseModal();
 
     return (
         <Box flexGrow={1}>
@@ -112,23 +108,7 @@ export function RoomContent({
                     </Heading>
                     {currentRoomEvent.shufflePeriod ? (
                         <Center>
-                            <Button
-                                flexDir="column"
-                                py={4}
-                                h="auto"
-                                colorScheme="blue"
-                                onClick={() => socialiseModal.onOpen(SocialiseModalTab.Networking)}
-                            >
-                                <HStack>
-                                    <FAIcon iconStyle="s" icon="hand-pointer" />
-                                    <chakra.span fontWeight="bold" mb={2}>
-                                        Participate in networking
-                                    </chakra.span>
-                                </HStack>
-                                <chakra.span mt={2} fontSize="lg" fontStyle="italic">
-                                    {currentRoomEvent.shufflePeriod.name}
-                                </chakra.span>
-                            </Button>
+                            <ShufflePeriodBox period={currentRoomEvent.shufflePeriod} />
                         </Center>
                     ) : (
                         <></>
@@ -164,6 +144,13 @@ export function RoomContent({
                             </Tag>
                         ) : undefined}
                     </HStack>
+                    {nextRoomEvent.shufflePeriod ? (
+                        <Center>
+                            <ShufflePeriodBox period={nextRoomEvent.shufflePeriod} />
+                        </Center>
+                    ) : (
+                        <></>
+                    )}
                     {nextRoomEvent?.itemId ? (
                         <ItemElementsWrapper itemId={nextRoomEvent.itemId} linkToItem={true} />
                     ) : (

--- a/frontend/src/aspects/ShuffleRooms/WaitingPage.tsx
+++ b/frontend/src/aspects/ShuffleRooms/WaitingPage.tsx
@@ -221,7 +221,7 @@ function QueuedShufflePeriodBox({
     }
 }
 
-function ShufflePeriodBox({ period }: { period: ShufflePeriodDataFragment }): JSX.Element {
+export function ShufflePeriodBox({ period }: { period: ShufflePeriodDataFragment }): JSX.Element {
     const now = useRealTime(1000);
     const currentRegistrant = useCurrentRegistrant();
     const conference = useConference();
@@ -346,14 +346,15 @@ export function ShuffleWaiting(): JSX.Element {
         variables: vars,
     });
 
-    const data = useMemo(() => (periods.data?.room_ShufflePeriod ? [...periods.data.room_ShufflePeriod] : null), [
-        periods.data?.room_ShufflePeriod,
-    ]);
+    const data = useMemo(
+        () => (periods.data?.room_ShufflePeriod ? [...periods.data.room_ShufflePeriod] : null),
+        [periods.data?.room_ShufflePeriod]
+    );
 
-    const ongoingQueues = useMemo(() => data?.filter((x) => Date.parse(x.startAt) <= 5 * 60 * 1000 + now.getTime()), [
-        data,
-        now,
-    ]);
+    const ongoingQueues = useMemo(
+        () => data?.filter((x) => Date.parse(x.startAt) <= 5 * 60 * 1000 + now.getTime()),
+        [data, now]
+    );
     const upcomingQueues = useMemo(
         () =>
             data

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -35845,7 +35845,10 @@ export type Room_GetEventsQuery = { readonly __typename?: 'query_root', readonly
     & Room_EventSummaryFragment
   )> };
 
-export type Room_EventSummaryFragment = { readonly __typename?: 'schedule_Event', readonly id: any, readonly conferenceId: any, readonly startTime: any, readonly name: string, readonly endTime?: Maybe<any>, readonly intendedRoomModeName: Room_Mode_Enum, readonly itemId?: Maybe<any>, readonly exhibitionId?: Maybe<any>, readonly shufflePeriod?: Maybe<{ readonly __typename?: 'room_ShufflePeriod', readonly id: any, readonly name: string }>, readonly item?: Maybe<{ readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly typeName: Content_ItemType_Enum, readonly chatId?: Maybe<any>, readonly videoElements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly name: string }>, readonly zoomItems: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly data: any, readonly name: string }> }>, readonly eventPeople: ReadonlyArray<{ readonly __typename?: 'schedule_EventProgramPerson', readonly id: any, readonly roleName: Schedule_EventProgramPersonRole_Enum, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly registrantId?: Maybe<any> } }> };
+export type Room_EventSummaryFragment = { readonly __typename?: 'schedule_Event', readonly id: any, readonly conferenceId: any, readonly startTime: any, readonly name: string, readonly endTime?: Maybe<any>, readonly intendedRoomModeName: Room_Mode_Enum, readonly itemId?: Maybe<any>, readonly exhibitionId?: Maybe<any>, readonly shufflePeriod?: Maybe<(
+    { readonly __typename?: 'room_ShufflePeriod' }
+    & ShufflePeriodDataFragment
+  )>, readonly item?: Maybe<{ readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly typeName: Content_ItemType_Enum, readonly chatId?: Maybe<any>, readonly videoElements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly name: string }>, readonly zoomItems: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly data: any, readonly name: string }> }>, readonly eventPeople: ReadonlyArray<{ readonly __typename?: 'schedule_EventProgramPerson', readonly id: any, readonly roleName: Schedule_EventProgramPersonRole_Enum, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly registrantId?: Maybe<any> } }> };
 
 export type Room_GetDefaultVideoRoomBackendQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -38760,6 +38763,39 @@ export const RoomEventDetailsFragmentDoc = gql`
   }
 }
     `;
+export const PrefetchShuffleQueueEntryDataFragmentDoc = gql`
+    fragment PrefetchShuffleQueueEntryData on room_ShuffleQueueEntry {
+  id
+  registrantId
+  created_at
+  updated_at
+  shuffleRoom {
+    id
+    startedAt
+    isEnded
+    roomId
+  }
+}
+    `;
+export const ShufflePeriodDataFragmentDoc = gql`
+    fragment ShufflePeriodData on room_ShufflePeriod {
+  id
+  conferenceId
+  endAt
+  maxRegistrantsPerRoom
+  name
+  queueEntries(
+    distinct_on: [registrantId]
+    order_by: {registrantId: asc, id: desc}
+  ) {
+    ...PrefetchShuffleQueueEntryData
+  }
+  roomDurationMinutes
+  startAt
+  targetRegistrantsPerRoom
+  waitRoomMaxDurationSeconds
+}
+    ${PrefetchShuffleQueueEntryDataFragmentDoc}`;
 export const Room_EventSummaryFragmentDoc = gql`
     fragment Room_EventSummary on schedule_Event {
   id
@@ -38771,8 +38807,7 @@ export const Room_EventSummaryFragmentDoc = gql`
   itemId
   exhibitionId
   shufflePeriod {
-    id
-    name
+    ...ShufflePeriodData
   }
   item {
     id
@@ -38803,7 +38838,7 @@ export const Room_EventSummaryFragmentDoc = gql`
     roleName
   }
 }
-    `;
+    ${ShufflePeriodDataFragmentDoc}`;
 export const RoomPage_RoomDetailsFragmentDoc = gql`
     fragment RoomPage_RoomDetails on room_Room {
   id
@@ -40143,39 +40178,6 @@ export const RoomParticipantDetailsFragmentDoc = gql`
   registrantId
 }
     `;
-export const PrefetchShuffleQueueEntryDataFragmentDoc = gql`
-    fragment PrefetchShuffleQueueEntryData on room_ShuffleQueueEntry {
-  id
-  registrantId
-  created_at
-  updated_at
-  shuffleRoom {
-    id
-    startedAt
-    isEnded
-    roomId
-  }
-}
-    `;
-export const ShufflePeriodDataFragmentDoc = gql`
-    fragment ShufflePeriodData on room_ShufflePeriod {
-  id
-  conferenceId
-  endAt
-  maxRegistrantsPerRoom
-  name
-  queueEntries(
-    distinct_on: [registrantId]
-    order_by: {registrantId: asc, id: desc}
-  ) {
-    ...PrefetchShuffleQueueEntryData
-  }
-  roomDurationMinutes
-  startAt
-  targetRegistrantsPerRoom
-  waitRoomMaxDurationSeconds
-}
-    ${PrefetchShuffleQueueEntryDataFragmentDoc}`;
 export const SubdShuffleQueueEntryDataFragmentDoc = gql`
     fragment SubdShuffleQueueEntryData on room_ShuffleQueueEntry {
   id

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -35602,13 +35602,15 @@ export type ContinuationChoices_ContinuationFragment = { readonly __typename?: '
 
 export type ContinuationChoices_ContinuationsQueryVariables = Exact<{
   fromId: Scalars['uuid'];
+  nowStart?: Maybe<Scalars['timestamptz']>;
+  nowEnd?: Maybe<Scalars['timestamptz']>;
 }>;
 
 
 export type ContinuationChoices_ContinuationsQuery = { readonly __typename?: 'query_root', readonly schedule_Continuation: ReadonlyArray<(
     { readonly __typename?: 'schedule_Continuation' }
     & ContinuationChoices_ContinuationFragment
-  )>, readonly room_ShufflePeriod: ReadonlyArray<{ readonly __typename?: 'room_ShufflePeriod', readonly id: any, readonly endAt: any, readonly roomDurationMinutes: number }>, readonly schedule_Event: ReadonlyArray<{ readonly __typename?: 'schedule_Event', readonly id: any, readonly endTime?: Maybe<any> }> };
+  )>, readonly room_ShufflePeriod: ReadonlyArray<{ readonly __typename?: 'room_ShufflePeriod', readonly id: any, readonly endAt: any, readonly roomDurationMinutes: number }>, readonly schedule_Event: ReadonlyArray<{ readonly __typename?: 'schedule_Event', readonly id: any, readonly roomId: any, readonly endTime?: Maybe<any> }> };
 
 export type ContinuationChoices_RoomsQueryVariables = Exact<{
   ids: ReadonlyArray<Scalars['uuid']> | Scalars['uuid'];
@@ -40804,7 +40806,7 @@ export type GetItemQueryHookResult = ReturnType<typeof useGetItemQuery>;
 export type GetItemLazyQueryHookResult = ReturnType<typeof useGetItemLazyQuery>;
 export type GetItemQueryResult = Apollo.QueryResult<GetItemQuery, GetItemQueryVariables>;
 export const ContinuationChoices_ContinuationsDocument = gql`
-    query ContinuationChoices_Continuations($fromId: uuid!) {
+    query ContinuationChoices_Continuations($fromId: uuid!, $nowStart: timestamptz, $nowEnd: timestamptz) {
   schedule_Continuation(
     where: {_or: [{fromEvent: {_eq: $fromId}}, {fromShuffleQueue: {_eq: $fromId}}]}
   ) {
@@ -40815,8 +40817,11 @@ export const ContinuationChoices_ContinuationsDocument = gql`
     endAt
     roomDurationMinutes
   }
-  schedule_Event(where: {id: {_eq: $fromId}}) {
+  schedule_Event(
+    where: {_or: [{id: {_eq: $fromId}}, {startTime: {_lte: $nowStart}, endTime: {_gte: $nowEnd}, shufflePeriodId: {_eq: $fromId}}]}
+  ) {
     id
+    roomId
     endTime
   }
 }

--- a/services/actions/src/handlers/shuffleRoom.ts
+++ b/services/actions/src/handlers/shuffleRoom.ts
@@ -267,11 +267,19 @@ async function attemptToMatchEntry_FCFS(
             const periodEndsAt = Date.parse(activePeriod.endAt);
             const timeRemaining = periodEndsAt - (now + roomDuration);
             const reshuffleUponEnd = timeRemaining > 60 * 1000;
+            const nowDate = new Date();
+            const timeStr = `${nowDate.getUTCFullYear()}/${nowDate.getUTCMonth().toString().padStart(2, "0")}/${nowDate
+                .getUTCDate()
+                .toString()
+                .padStart(2, "0")} ${nowDate.getUTCHours().toString().padStart(2, "0")}:${nowDate
+                .getUTCMinutes()
+                .toString()
+                .padStart(2, "0")}`;
             activeRooms.push(
                 await allocateToNewRoom(
                     activePeriod.id,
                     activePeriod.maxRegistrantsPerRoom + 1,
-                    activePeriod.name + " room " + new Date().toISOString(),
+                    activePeriod.name + " room: " + timeStr,
                     activePeriod.conferenceId,
                     activePeriod.roomDurationMinutes,
                     reshuffleUponEnd,


### PR DESCRIPTION
## What's improved

This PR introduces three improvements to shuffle-mode events. One of these improvements will significantly reduce the work needed by an organiser to set up the common format of shuffle events.

1. Instead of showing the "Click to open the Networking modal" button on events, the actual Shuffle Queue Tile is now shown. This enables someone to join the queue directly, which is a much less confusing UX. In addition, the Join button is shown for upcoming events, which should enable people to join in advance.
2. The names of generated shuffle rooms is improved slightly.
3. When a shuffle room ends, it previously always directed someone back to the main "shuffle queues list" waiting page (and activated any continuation choice). Now, if an event exists for the current shuffle queue, the default is to direct people to the room for that event.
 
The original behaviour of (3) meant organisers would have to configure a default-selected continuation from the shuffle period. It also meant that if a shuffle room ended before the end of the queue, the user would be left sitting on the main shuffle queues page - and potentially miss the start of the next event in the session they thought they were participating in. With the tweaked mechanism, by default users will end up back in the room for the session they were participating in. This avoids the need for any continuations and avoids people "getting stuck" on the Shuffle Queues page.

## Upgrading

* Developers should re-run GraphQL Codegen. 

## Deployment

This requires redeployment of the Actions Service and frontend.