### PR TITLE
Improvement/room ux

### DIFF
--- a/frontend/src/aspects/App/AppPageV2.tsx
+++ b/frontend/src/aspects/App/AppPageV2.tsx
@@ -99,15 +99,7 @@ export default function AppPageV2(): JSX.Element {
             mr={rightVisible ? 0 : [2, 2, 2, 4]}
             pr={rightVisible ? 2 : 0}
         >
-            <VStack
-                mt={2}
-                spacing={5}
-                width="100%"
-                mb="40px"
-                overflow="hidden"
-                role="region"
-                aria-labelledby="page-heading"
-            >
+            <VStack spacing={5} width="100%" mb="40px" role="region" aria-labelledby="page-heading">
                 {center}
             </VStack>
         </Box>

--- a/frontend/src/aspects/Conference/Attend/ConferenceLandingPage.tsx
+++ b/frontend/src/aspects/Conference/Attend/ConferenceLandingPage.tsx
@@ -136,10 +136,12 @@ function ConferenceLandingPageInner(): JSX.Element {
         <>
             {title}
             {!hasAbstract ? (
-                <Heading as="h1" id="page-heading">
+                <Heading as="h1" id="page-heading" mt={2}>
                     {conference.shortName}
                 </Heading>
-            ) : undefined}
+            ) : (
+                <Box h="0">&nbsp;</Box>
+            )}
             <ConferenceLandingContent group={group} />
         </>
     );

--- a/frontend/src/aspects/Conference/Attend/Room/Event/EventRoomControlPanel.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Event/EventRoomControlPanel.tsx
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 import {
     Box,
     Button,
-    Flex,
+    HStack,
     Popover,
     PopoverArrow,
     PopoverBody,
@@ -13,7 +13,6 @@ import {
     Portal,
     Spinner,
     Text,
-    useBreakpointValue,
     VStack,
 } from "@chakra-ui/react";
 import React, { useEffect, useMemo, useState } from "react";
@@ -141,11 +140,8 @@ export function EventRoomControlPanel({ event }: { event: RoomEventDetailsFragme
         [event.id, live, secondsUntilOffAir, isConnected]
     );
 
-    const insertSpacer = useBreakpointValue([false, false, true]);
     return (
-        <Flex w="100%" p={2} flexWrap="wrap" alignItems="center" justifyContent="space-between">
-            {/* Add a spacer of equal width to the Broadcast Controls button, so that the time info is centered */}
-            {insertSpacer ? <Box w={"10em"}>&nbsp;</Box> : <></>}
+        <>
             <LiveIndicator
                 live={live}
                 secondsUntilLive={secondsUntilLive}
@@ -154,10 +150,10 @@ export function EventRoomControlPanel({ event }: { event: RoomEventDetailsFragme
                 eventId={event.id}
                 isConnected={isConnected}
             />
-            <VStack justifyContent="center" alignItems="flex-end" my={2}>
+            <HStack flexWrap="wrap" w="100%" justifyContent="center" alignItems="flex-end" my={2}>
                 {immediateSwitchControls}
                 {broadcastPopover}
-            </VStack>
-        </Flex>
+            </HStack>
+        </>
     );
 }

--- a/frontend/src/aspects/Conference/Attend/Room/Event/LiveIndicator.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Event/LiveIndicator.tsx
@@ -12,6 +12,7 @@ import {
     StatLabel,
     StatNumber,
     Text,
+    useColorModeValue,
     useDisclosure,
     VStack,
 } from "@chakra-ui/react";
@@ -202,6 +203,7 @@ export function LiveIndicator({
         }
     }, [currentInput, isConnected]);
 
+    const bgColor = useColorModeValue("gray.100", "gray.800");
     return (
         <>
             <Modal isOpen={shouldModalBeOpen} onClose={onClose} isCentered>
@@ -212,31 +214,35 @@ export function LiveIndicator({
                             <Heading>
                                 You will be live the moment the indicator says &ldquo;Backstage is live&rdquo;.
                             </Heading>
-                            <Text>DO NOT ASK THE AUDIENCE WHEN YOU ARE LIVE!</Text>
+                            <Text>Please do not ask the audience when you are live.</Text>
                             <Text>
                                 The audience sees the stream with a bit of lag - anywhere from 5 to 30 seconds depending
                                 on where they are in the world. So they can&apos;t give you real-time feedback about the
                                 stream. Also, if there were a technical glitch (meaning your stream was not live) you
-                                can trust that the audience will quickly start telling you via the chat!
+                                can trust that the audience will quickly start telling you via the chat.
                             </Text>
                             <Text>
-                                So please trust the countdown - it is accurate and reliable. If it says the backstage is
-                                live, then you are live in front of the entire conference and should start your
-                                presentation or Q&amp;A session (or whatever it is you&apos;re here to do).
+                                The countdown is accurate and reliable. If it says the backstage is live, then you are
+                                live in front of the entire conference and should start your presentation or Q&amp;A
+                                session.
                             </Text>
-                            <Text>
-                                Please try not to be &ldquo;that person&rdquo; that wastes the first 2 minutes of their
-                                stream trying to check &ldquo;am I live&rdquo;!
-                            </Text>
-                            <Text>
-                                (Also, please open the chat sidebar while you are off air - i.e. ahead of time!)
-                            </Text>
+                            <Text>(Also, please open the chat sidebar ahead of time, while you are off air.)</Text>
                         </VStack>
                     </ModalBody>
                 </ModalContent>
             </Modal>
             {live ? (
-                <HStack alignItems="stretch" justifyContent="flex-start" mx="auto" flexWrap="wrap">
+                <HStack
+                    alignItems="stretch"
+                    justifyContent="flex-start"
+                    mx="auto"
+                    flexWrap="wrap"
+                    pos="sticky"
+                    top={0}
+                    bgColor={bgColor}
+                    zIndex={10000}
+                    overflow="visible"
+                >
                     <Badge
                         fontSize={isConnected ? "lg" : "md"}
                         colorScheme="red"
@@ -254,7 +260,17 @@ export function LiveIndicator({
                     </Stat>
                 </HStack>
             ) : (
-                <HStack alignItems="stretch" justifyContent="flex-start" mx="auto" flexWrap="wrap">
+                <HStack
+                    alignItems="stretch"
+                    justifyContent="flex-start"
+                    mx="auto"
+                    flexWrap="wrap"
+                    pos="sticky"
+                    top={0}
+                    bgColor={bgColor}
+                    zIndex={10000}
+                    overflow="visible"
+                >
                     {secondsUntilLive > 0 ? (
                         <>
                             <Badge
@@ -299,9 +315,7 @@ export function LiveIndicator({
                             )}
                             {secondsUntilLive > 10 ? (
                                 <Button onClick={onOpen} h="auto" maxH="auto" p={3} colorScheme="blue" size="sm">
-                                    When will I be live?
-                                    <br />
-                                    Click to learn.
+                                    What should I do?
                                 </Button>
                             ) : undefined}
                         </>

--- a/frontend/src/aspects/Conference/Attend/Room/Room.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Room.tsx
@@ -633,19 +633,19 @@ function RoomInner({
         () => (
             <>
                 {showDefaultBreakoutRoom && secondsUntilBreakoutRoomCloses <= 180 ? (
-                    <Alert status="warning">
+                    <Alert status="warning" pos="sticky" top={0} zIndex={10000}>
                         <AlertIcon />
                         Video-chat closes in {Math.round(secondsUntilBreakoutRoomCloses)} seconds
                     </Alert>
                 ) : undefined}
                 {secondsUntilZoomEvent > 0 && secondsUntilZoomEvent < 180 && !currentRoomEvent ? (
-                    <Alert status="info">
+                    <Alert status="info" pos="sticky" top={0} zIndex={10000}>
                         <AlertIcon />
                         Zoom event starting in {Math.round(secondsUntilZoomEvent)} seconds
                     </Alert>
                 ) : undefined}
                 {secondsUntilBroadcastEvent > 0 && secondsUntilBroadcastEvent < 180 ? (
-                    <Alert status="info">
+                    <Alert status="info" pos="sticky" top={0} zIndex={10000}>
                         <AlertIcon />
                         Livestream event starting in {Math.round(secondsUntilBroadcastEvent)} seconds
                     </Alert>


### PR DESCRIPTION
Minor improvements to make the "X is ending" and "You are live"/Countdown messages better.

* Make the messages sticky to the top of the screen so scrolling doesn't hide them
* Make the "Video chat closes in" message show when a Breakout event is ending (even if it isn't followed by another event)