### PR TITLE
Improvement/navigation

### DIFF
--- a/frontend/src/aspects/App/AppPageV2.tsx
+++ b/frontend/src/aspects/App/AppPageV2.tsx
@@ -30,7 +30,7 @@ export default function AppPageV2(): JSX.Element {
     // const isAdminPage = !!useRouteMatch("/conference/:confSlug/manage/");
     const centerAlwaysVisible = useBreakpointValue({
         base: false,
-        md: true,
+        lg: true,
     });
     const [rightOpen, setRightOpen] = useState<boolean>(false);
     const rightVisible = isPermittedAccess && !!rightOpen;
@@ -159,13 +159,18 @@ function RightBar({
     rightVisible: boolean;
     rightSidebarWidthPc: number;
 }): JSX.Element {
+    const width = useBreakpointValue({
+        base: "400px",
+        xl: "500px",
+        "2xl": "600px",
+    });
     return (
         <Box
             zIndex={2}
             overflow={"visible"}
             height="100%"
             width={rightVisible ? (centerVisible ? rightSidebarWidthPc + "%" : "100%") : "auto"}
-            maxWidth={centerVisible ? "550px" : undefined}
+            maxWidth={centerVisible ? width : undefined}
             flex={rightVisible ? "1 0 300px" : "0 1 auto"}
             display="flex"
             flexDir="column"

--- a/frontend/src/aspects/Auth/Buttons/LoginButton.tsx
+++ b/frontend/src/aspects/Auth/Buttons/LoginButton.tsx
@@ -11,6 +11,7 @@ export default function LoginButton({
     size,
     emailHint,
     isLoading,
+    showLabel,
 }: {
     size?: string;
     asMenuItem?: boolean;
@@ -18,6 +19,7 @@ export default function LoginButton({
     redirectTo?: string;
     emailHint?: string;
     isLoading?: boolean;
+    showLabel?: boolean;
 }): JSX.Element {
     const { loginWithRedirect } = useAuth0();
     const location = useLocation();
@@ -37,9 +39,11 @@ export default function LoginButton({
             iconStyle="s"
             icon="sign-in-alt"
             borderRadius={0}
-            colorScheme="green"
+            colorScheme="purple"
             side="right"
             onClick={() => loginWithRedirect(opts)}
+            mb={1}
+            showLabel={showLabel}
         />
     ) : asMenuItem ? (
         <MenuItem size={size ?? "sm"} onClick={() => loginWithRedirect(opts)} colorScheme="purple">

--- a/frontend/src/aspects/Auth/Buttons/LogoutButton.tsx
+++ b/frontend/src/aspects/Auth/Buttons/LogoutButton.tsx
@@ -20,9 +20,10 @@ export default function LogoutButton({
             iconStyle="s"
             icon="sign-out-alt"
             borderRadius={0}
-            colorScheme="transparent"
+            colorScheme="purple"
             side="right"
             onClick={() => logout({ returnTo })}
+            mb={1}
         />
     ) : asMenuItem ? (
         <MenuItem size="sm" onClick={() => logout({ returnTo })}>

--- a/frontend/src/aspects/Auth/Buttons/LogoutButton.tsx
+++ b/frontend/src/aspects/Auth/Buttons/LogoutButton.tsx
@@ -2,12 +2,29 @@ import { useAuth0 } from "@auth0/auth0-react";
 import { Button, MenuItem, Tooltip } from "@chakra-ui/react";
 import React, { useMemo } from "react";
 import FAIcon from "../../Icons/FAIcon";
+import MenuButton from "../../Menu/V2/MenuButton";
 
-export default function LogoutButton({ asMenuItem }: { asMenuItem?: boolean }): JSX.Element {
+export default function LogoutButton({
+    asMenuItem,
+    asMenuButtonV2,
+}: {
+    asMenuItem?: boolean;
+    asMenuButtonV2?: boolean;
+}): JSX.Element {
     const { logout } = useAuth0();
     const returnTo = useMemo(() => `${window.location.origin}/auth0/logged-out`, []);
 
-    return asMenuItem ? (
+    return asMenuButtonV2 ? (
+        <MenuButton
+            label="Logout"
+            iconStyle="s"
+            icon="sign-out-alt"
+            borderRadius={0}
+            colorScheme="transparent"
+            side="right"
+            onClick={() => logout({ returnTo })}
+        />
+    ) : asMenuItem ? (
         <MenuItem size="sm" onClick={() => logout({ returnTo })}>
             <FAIcon iconStyle="s" icon="sign-out-alt" mr={2} aria-hidden={true} /> Log Out
         </MenuItem>

--- a/frontend/src/aspects/Auth/Buttons/LogoutButton.tsx
+++ b/frontend/src/aspects/Auth/Buttons/LogoutButton.tsx
@@ -7,9 +7,11 @@ import MenuButton from "../../Menu/V2/MenuButton";
 export default function LogoutButton({
     asMenuItem,
     asMenuButtonV2,
+    showLabel,
 }: {
     asMenuItem?: boolean;
     asMenuButtonV2?: boolean;
+    showLabel?: boolean;
 }): JSX.Element {
     const { logout } = useAuth0();
     const returnTo = useMemo(() => `${window.location.origin}/auth0/logged-out`, []);
@@ -24,6 +26,7 @@ export default function LogoutButton({
             side="right"
             onClick={() => logout({ returnTo })}
             mb={1}
+            showLabel={showLabel}
         />
     ) : asMenuItem ? (
         <MenuItem size="sm" onClick={() => logout({ returnTo })}>

--- a/frontend/src/aspects/Conference/Attend/Rooms/V2/SocialiseModal.tsx
+++ b/frontend/src/aspects/Conference/Attend/Rooms/V2/SocialiseModal.tsx
@@ -6,7 +6,6 @@ import {
     ModalCloseButton,
     ModalContent,
     ModalFooter,
-    ModalHeader,
     ModalOverlay,
     Tab,
     TabList,
@@ -176,18 +175,19 @@ export default function SocialiseModal({
             >
                 <ModalOverlay />
                 <ModalContent>
-                    <ModalHeader>Socialise</ModalHeader>
                     <ModalCloseButton ref={closeRef} />
-                    <ModalBody>
+                    <ModalBody display="flex" justifyContent="center" overflow="hidden">
                         <Tabs
-                            isFitted
                             variant="enclosed-colored"
                             colorScheme="purple"
                             isLazy
+                            w="100%"
+                            display="flex"
+                            flexDir="column"
                             index={selectedTabIndex}
                             onChange={setSelectedTabFromIndex}
                         >
-                            <TabList>
+                            <TabList justifyContent="center">
                                 <Tab>
                                     <FAIcon iconStyle="s" icon="mug-hot" aria-hidden />
                                     &nbsp;&nbsp;Rooms

--- a/frontend/src/aspects/Conference/Attend/Schedule/ProgramModal.tsx
+++ b/frontend/src/aspects/Conference/Attend/Schedule/ProgramModal.tsx
@@ -188,9 +188,10 @@ export function ScheduleModal({
 
     const [anyHappeningSoon, setAnyHappeningSoon] = useState<boolean>(false);
     const now = useRealTime(15 * 60 * 1000);
-    const endAfter = useMemo(() => new Date(roundDownToNearest(now - 10 * 60 * 1000, 5 * 60 * 1000)).toISOString(), [
-        now,
-    ]);
+    const endAfter = useMemo(
+        () => new Date(roundDownToNearest(now - 10 * 60 * 1000, 5 * 60 * 1000)).toISOString(),
+        [now]
+    );
     const startBefore = useMemo(
         () => new Date(roundUpToNearest(now + 2 * 60 * 60 * 1000, 15 * 60 * 1000)).toISOString(),
         [now]
@@ -244,9 +245,10 @@ export function ScheduleModal({
     useEffect(() => {
         setAnySponsors?.(!!result.data && result.data.content_Item.length > 0);
     }, [setAnySponsors, result.data]);
-    const sponsors = useMemo(() => <SponsorBoothsInner sponsors={result.data?.content_Item ?? []} />, [
-        result.data?.content_Item,
-    ]);
+    const sponsors = useMemo(
+        () => <SponsorBoothsInner sponsors={result.data?.content_Item ?? []} />,
+        [result.data?.content_Item]
+    );
 
     const selectedTabIndex = useMemo(() => {
         const offset1 = anyHappeningSoon ? 1 : 0;
@@ -339,6 +341,8 @@ export function ScheduleModal({
                         w="100%"
                         display="flex"
                         flexDir="column"
+                        variant="enclosed-colored"
+                        colorScheme="purple"
                         index={selectedTabIndex}
                         onChange={setSelectedTabFromIndex}
                     >

--- a/frontend/src/aspects/Menu/V2/LeftMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/LeftMenu.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Link, MenuDivider, MenuItem, useBreakpointValue } from "@chakra-ui/react";
+import { Box, Flex, Link, MenuDivider, MenuItem } from "@chakra-ui/react";
 import * as R from "ramda";
 import React, { Fragment, useEffect } from "react";
 import { Link as ReactLink, useHistory, useLocation } from "react-router-dom";
@@ -11,6 +11,7 @@ import { useStarredEventsModal } from "../../Conference/Attend/Schedule/StarredE
 import RequireAtLeastOnePermissionWrapper from "../../Conference/RequireAtLeastOnePermissionWrapper";
 import { useConference } from "../../Conference/useConference";
 import { useMaybeCurrentRegistrant } from "../../Conference/useCurrentRegistrant";
+import { useRestorableState } from "../../Generic/useRestorableState";
 import FAIcon from "../../Icons/FAIcon";
 import { useLiveEvents } from "../../LiveEvents/LiveEvents";
 import useRoomParticipants from "../../Room/useRoomParticipants";
@@ -71,20 +72,35 @@ export default function LeftMenu(): JSX.Element {
     const liveRoomCount = Object.keys(liveEventsByRoom).length;
     const showLive = liveRoomCount > 0;
 
-    const barWidth = useBreakpointValue({
-        base: "3em",
-        lg: "4em",
-    });
+    const [isExpanded, setIsExpanded] = useRestorableState<boolean>(
+        "LeftMenu_IsExpanded",
+        true,
+        (x) => x.toString(),
+        (x) => x === "true"
+    );
     return (
         <>
-            <Flex
-                flexDir="column"
-                justifyContent="center"
-                alignItems="flex-start"
-                minW={barWidth}
-                h="100%"
-                bgColor="blue.600"
-            >
+            <Flex flexDir="column" justifyContent="center" alignItems="flex-start" h="100%" bgColor="blue.600">
+                <MenuButton
+                    label={isExpanded ? "Collapse menu" : "Expand menu"}
+                    iconStyle="s"
+                    icon={isExpanded ? ["arrow-left", "grip-lines-vertical"] : ["grip-lines-vertical", "arrow-right"]}
+                    borderTopRadius={0}
+                    colorScheme={colorScheme}
+                    side="right"
+                    mb={1}
+                    showLabel={false}
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    fontSize="xs"
+                    justifyContent="center"
+                    w="auto"
+                    minW="auto"
+                    alignSelf="flex-end"
+                    minH={0}
+                    h="auto"
+                    lineHeight={0}
+                    m={1.5}
+                />
                 <MenuButton
                     label="Home"
                     iconStyle="s"
@@ -97,6 +113,7 @@ export default function LeftMenu(): JSX.Element {
                     }}
                     mt="auto"
                     mb={1}
+                    showLabel={isExpanded}
                 />
                 {showLive ? (
                     <MenuButton
@@ -109,6 +126,7 @@ export default function LeftMenu(): JSX.Element {
                         ref={liveNowButtonRef as React.RefObject<HTMLButtonElement>}
                         onClick={liveNow_OnOpen}
                         mb={1}
+                        showLabel={isExpanded}
                     >
                         <Box pos="absolute" top={1} right={1} fontSize="xs">
                             {liveRoomCount}
@@ -126,6 +144,7 @@ export default function LeftMenu(): JSX.Element {
                     ref={scheduleButtonRef as React.RefObject<HTMLButtonElement>}
                     onClick={() => schedule_OnOpen()}
                     mb={maybeRegistrant ? 1 : "auto"}
+                    showLabel={isExpanded}
                 />
                 {maybeRegistrant ? (
                     <>
@@ -148,6 +167,7 @@ export default function LeftMenu(): JSX.Element {
                             ref={socialiseButtonRef as React.RefObject<HTMLButtonElement>}
                             onClick={() => socialise_OnOpen()}
                             mb={1}
+                            showLabel={isExpanded}
                         >
                             {roomParticipants !== undefined &&
                             roomParticipants !== false &&
@@ -165,6 +185,7 @@ export default function LeftMenu(): JSX.Element {
                             colorScheme={colorScheme}
                             side="left"
                             mb="auto"
+                            showLabel={isExpanded}
                         >
                             <MenuItem
                                 ref={myStarredEventsButtonRef as React.RefObject<HTMLButtonElement>}
@@ -207,6 +228,7 @@ export default function LeftMenu(): JSX.Element {
                         colorScheme={colorScheme}
                         side="left"
                         mb={1}
+                        showLabel={isExpanded}
                     >
                         <MenuItem as={ReactLink} to={`/conference/${conference.slug}/manage/checklist`}>
                             <FAIcon iconStyle="s" icon="check" mr={2} aria-hidden={true} w="1.2em" />
@@ -248,6 +270,7 @@ export default function LeftMenu(): JSX.Element {
                         colorScheme={colorScheme}
                         side="left"
                         mb={1}
+                        showLabel={isExpanded}
                     >
                         {R.sortBy((registrant) => registrant.conference.shortName, maybeUser.registrants).map(
                             (registrant) =>
@@ -281,6 +304,8 @@ export default function LeftMenu(): JSX.Element {
                     side="left"
                     as={Link}
                     href="https://github.com/clowdr-app/clowdr/issues"
+                    showLabel={isExpanded}
+                    textDecoration="none"
                 />
             </Flex>
         </>

--- a/frontend/src/aspects/Menu/V2/LeftMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/LeftMenu.tsx
@@ -149,7 +149,8 @@ export default function LeftMenu(): JSX.Element {
                 {maybeRegistrant ? (
                     <>
                         <MenuButton
-                            label={
+                            label="Socialise"
+                            ariaLabel={
                                 roomParticipants !== undefined &&
                                 roomParticipants !== false &&
                                 roomParticipants.length > 0

--- a/frontend/src/aspects/Menu/V2/LeftMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/LeftMenu.tsx
@@ -3,6 +3,7 @@ import * as R from "ramda";
 import React, { Fragment, useEffect } from "react";
 import { Link as ReactLink, useHistory, useLocation } from "react-router-dom";
 import { Permissions_Permission_Enum } from "../../../generated/graphql";
+import LogoutButton from "../../Auth/Buttons/LogoutButton";
 import { useMyBackstagesModal } from "../../Conference/Attend/Profile/MyBackstages";
 import { useLiveProgramRoomsModal } from "../../Conference/Attend/Rooms/V2/LiveProgramRoomsModal";
 import { useSocialiseModal } from "../../Conference/Attend/Rooms/V2/SocialiseModal";
@@ -187,6 +188,7 @@ export default function LeftMenu(): JSX.Element {
                             side="left"
                             mb="auto"
                             showLabel={isExpanded}
+                            imageSrc={maybeRegistrant.profile.photoURL_50x50 ?? undefined}
                         >
                             <MenuItem
                                 ref={myStarredEventsButtonRef as React.RefObject<HTMLButtonElement>}
@@ -206,6 +208,7 @@ export default function LeftMenu(): JSX.Element {
                                 <FAIcon iconStyle="s" icon="person-booth" mr={2} aria-hidden={true} w="1.2em" /> My
                                 backstages
                             </MenuItem>
+                            <LogoutButton asMenuItem showLabel={isExpanded} />
                         </MoreOptionsMenuButton>
                     </>
                 ) : undefined}

--- a/frontend/src/aspects/Menu/V2/LeftMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/LeftMenu.tsx
@@ -291,7 +291,7 @@ export default function LeftMenu(): JSX.Element {
                                     </MenuItem>
                                 )
                         )}
-                        {maybeUser.registrants.length ? <MenuDivider /> : undefined}
+                        {!conference || maybeUser.registrants.length > 1 ? <MenuDivider /> : undefined}
                         <MenuItem as={ReactLink} to="/join">
                             <FAIcon iconStyle="s" icon="ticket-alt" />
                             &nbsp;&nbsp; Use invite code

--- a/frontend/src/aspects/Menu/V2/LeftMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/LeftMenu.tsx
@@ -18,7 +18,7 @@ import useMaybeCurrentUser from "../../Users/CurrentUser/useMaybeCurrentUser";
 import MenuButton from "./MenuButton";
 import MoreOptionsMenuButton from "./MoreOptionsMenuButton";
 
-const colorScheme = "transparent";
+const colorScheme = "blue";
 export default function LeftMenu(): JSX.Element {
     const conference = useConference();
     const maybeUser = useMaybeCurrentUser()?.user;
@@ -72,8 +72,8 @@ export default function LeftMenu(): JSX.Element {
     const showLive = liveRoomCount > 0;
 
     const barWidth = useBreakpointValue({
-        base: "3.6em",
-        lg: "4.5em",
+        base: "3em",
+        lg: "4em",
     });
     return (
         <>
@@ -83,10 +83,10 @@ export default function LeftMenu(): JSX.Element {
                 alignItems="flex-start"
                 minW={barWidth}
                 h="100%"
-                bgColor="blue.500"
+                bgColor="blue.600"
             >
                 <MenuButton
-                    label="Conference home"
+                    label="Home"
                     iconStyle="s"
                     icon="home"
                     borderRadius={0}
@@ -96,10 +96,11 @@ export default function LeftMenu(): JSX.Element {
                         history.push(`/conference/${conference.slug}`);
                     }}
                     mt="auto"
+                    mb={1}
                 />
                 {showLive ? (
                     <MenuButton
-                        label={`Live now: ${liveRoomCount} rooms`}
+                        label="Live now"
                         iconStyle="s"
                         icon="podcast"
                         borderBottomRadius={0}
@@ -107,6 +108,7 @@ export default function LeftMenu(): JSX.Element {
                         side="left"
                         ref={liveNowButtonRef as React.RefObject<HTMLButtonElement>}
                         onClick={liveNow_OnOpen}
+                        mb={1}
                     >
                         <Box pos="absolute" top={1} right={1} fontSize="xs">
                             {liveRoomCount}
@@ -114,16 +116,16 @@ export default function LeftMenu(): JSX.Element {
                     </MenuButton>
                 ) : undefined}
                 <MenuButton
-                    label="Explore program"
+                    label="Program"
                     iconStyle="s"
-                    icon={["calendar", "search"]}
+                    icon={"calendar"}
                     px={0}
                     borderRadius={0}
                     colorScheme={colorScheme}
                     side="left"
                     ref={scheduleButtonRef as React.RefObject<HTMLButtonElement>}
                     onClick={() => schedule_OnOpen()}
-                    mb={maybeRegistrant ? undefined : "auto"}
+                    mb={maybeRegistrant ? 1 : "auto"}
                 />
                 {maybeRegistrant ? (
                     <>
@@ -145,6 +147,7 @@ export default function LeftMenu(): JSX.Element {
                             pos="relative"
                             ref={socialiseButtonRef as React.RefObject<HTMLButtonElement>}
                             onClick={() => socialise_OnOpen()}
+                            mb={1}
                         >
                             {roomParticipants !== undefined &&
                             roomParticipants !== false &&
@@ -197,12 +200,13 @@ export default function LeftMenu(): JSX.Element {
                     ]}
                 >
                     <MoreOptionsMenuButton
-                        label="Manage conference"
+                        label="Manage"
                         iconStyle="s"
                         icon="cog"
                         borderRadius={0}
                         colorScheme={colorScheme}
                         side="left"
+                        mb={1}
                     >
                         <MenuItem as={ReactLink} to={`/conference/${conference.slug}/manage/checklist`}>
                             <FAIcon iconStyle="s" icon="check" mr={2} aria-hidden={true} w="1.2em" />
@@ -237,12 +241,13 @@ export default function LeftMenu(): JSX.Element {
                 </RequireAtLeastOnePermissionWrapper>
                 {maybeUser ? (
                     <MoreOptionsMenuButton
-                        label="My conferences"
+                        label="Conferences"
                         iconStyle="s"
                         icon="ticket-alt"
                         borderRadius={0}
                         colorScheme={colorScheme}
                         side="left"
+                        mb={1}
                     >
                         {R.sortBy((registrant) => registrant.conference.shortName, maybeUser.registrants).map(
                             (registrant) =>

--- a/frontend/src/aspects/Menu/V2/LeftMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/LeftMenu.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Link, MenuDivider, MenuItem, Text, useBreakpointValue } from "@chakra-ui/react";
+import { Box, Flex, Link, MenuDivider, MenuItem, useBreakpointValue } from "@chakra-ui/react";
 import * as R from "ramda";
 import React, { Fragment, useEffect } from "react";
 import { Link as ReactLink, useHistory, useLocation } from "react-router-dom";
@@ -18,7 +18,7 @@ import useMaybeCurrentUser from "../../Users/CurrentUser/useMaybeCurrentUser";
 import MenuButton from "./MenuButton";
 import MoreOptionsMenuButton from "./MoreOptionsMenuButton";
 
-const colorScheme = "blue";
+const colorScheme = "transparent";
 export default function LeftMenu(): JSX.Element {
     const conference = useConference();
     const maybeUser = useMaybeCurrentUser()?.user;
@@ -72,16 +72,31 @@ export default function LeftMenu(): JSX.Element {
     const showLive = liveRoomCount > 0;
 
     const barWidth = useBreakpointValue({
-        base: "3em",
-        lg: "4em",
+        base: "3.6em",
+        lg: "4.5em",
     });
-
     return (
         <>
-            <Flex flexDir="column" w={barWidth} justifyContent="center" alignItems="flex-start">
-                <Text fontSize="xs" textAlign="left" ml={1} mb={2}>
-                    Navigate
-                </Text>
+            <Flex
+                flexDir="column"
+                justifyContent="center"
+                alignItems="flex-start"
+                minW={barWidth}
+                h="100%"
+                bgColor="blue.500"
+            >
+                <MenuButton
+                    label="Conference home"
+                    iconStyle="s"
+                    icon="home"
+                    borderRadius={0}
+                    colorScheme={colorScheme}
+                    side="left"
+                    onClick={() => {
+                        history.push(`/conference/${conference.slug}`);
+                    }}
+                    mt="auto"
+                />
                 {showLive ? (
                     <MenuButton
                         label={`Live now: ${liveRoomCount} rooms`}
@@ -108,6 +123,7 @@ export default function LeftMenu(): JSX.Element {
                     side="left"
                     ref={scheduleButtonRef as React.RefObject<HTMLButtonElement>}
                     onClick={() => schedule_OnOpen()}
+                    mb={maybeRegistrant ? undefined : "auto"}
                 />
                 {maybeRegistrant ? (
                     <>
@@ -145,6 +161,7 @@ export default function LeftMenu(): JSX.Element {
                             borderRadius={0}
                             colorScheme={colorScheme}
                             side="left"
+                            mb="auto"
                         >
                             <MenuItem
                                 ref={myStarredEventsButtonRef as React.RefObject<HTMLButtonElement>}
@@ -167,17 +184,6 @@ export default function LeftMenu(): JSX.Element {
                         </MoreOptionsMenuButton>
                     </>
                 ) : undefined}
-                <MenuButton
-                    label="Conference home"
-                    iconStyle="s"
-                    icon="home"
-                    borderRadius={0}
-                    colorScheme={colorScheme}
-                    side="left"
-                    onClick={() => {
-                        history.push(`/conference/${conference.slug}`);
-                    }}
-                />
                 <RequireAtLeastOnePermissionWrapper
                     permissions={[
                         Permissions_Permission_Enum.ConferenceManageAttendees,
@@ -195,7 +201,7 @@ export default function LeftMenu(): JSX.Element {
                         iconStyle="s"
                         icon="cog"
                         borderRadius={0}
-                        colorScheme="gray"
+                        colorScheme={colorScheme}
                         side="left"
                     >
                         <MenuItem as={ReactLink} to={`/conference/${conference.slug}/manage/checklist`}>
@@ -235,7 +241,7 @@ export default function LeftMenu(): JSX.Element {
                         iconStyle="s"
                         icon="ticket-alt"
                         borderRadius={0}
-                        colorScheme="gray"
+                        colorScheme={colorScheme}
                         side="left"
                     >
                         {R.sortBy((registrant) => registrant.conference.shortName, maybeUser.registrants).map(
@@ -266,7 +272,7 @@ export default function LeftMenu(): JSX.Element {
                     iconStyle="s"
                     icon="comment-medical"
                     borderTopRadius={0}
-                    colorScheme="gray"
+                    colorScheme={colorScheme}
                     side="left"
                     as={Link}
                     href="https://github.com/clowdr-app/clowdr/issues"

--- a/frontend/src/aspects/Menu/V2/LeftMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/LeftMenu.tsx
@@ -112,7 +112,6 @@ export default function LeftMenu(): JSX.Element {
                     onClick={() => {
                         history.push(`/conference/${conference.slug}`);
                     }}
-                    mt="auto"
                     mb={1}
                     showLabel={isExpanded}
                 />

--- a/frontend/src/aspects/Menu/V2/MenuButton.tsx
+++ b/frontend/src/aspects/Menu/V2/MenuButton.tsx
@@ -1,6 +1,5 @@
-import { As, Button, PropsOf, useBreakpointValue } from "@chakra-ui/react";
+import { As, Button, chakra, PropsOf, useBreakpointValue } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
-import { defaultOutline_AsBoxShadow } from "../../Chakra/Outline";
 import { FAIcon } from "../../Icons/FAIcon";
 
 type Props<T extends As<any> = typeof Button> = PropsOf<T> & {
@@ -19,40 +18,26 @@ function intermingle<T>(fn: (idx: number) => T) {
 }
 
 const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
-    { label, iconStyle, icon, side, children, ...props }: React.PropsWithChildren<Props>,
+    { label, iconStyle, icon, children, ...props }: React.PropsWithChildren<Props>,
     ref
 ): JSX.Element {
     const size = useBreakpointValue({
         base: "md",
         lg: "lg",
     });
-    const expandedFontSize = useBreakpointValue({
-        base: "lg",
-        lg: "xl",
-    });
     return (
         <Button
             aria-label={label}
             size={size}
-            color="white"
             p={0}
             minW="100%"
-            _hover={{
-                fontSize: expandedFontSize,
-                borderLeftRadius: side === "right" ? 2 : undefined,
-                borderRightRadius: side === "left" ? 2 : undefined,
-            }}
-            _focus={{
-                fontSize: expandedFontSize,
-                borderLeftRadius: side === "right" ? 2 : undefined,
-                borderRightRadius: side === "left" ? 2 : undefined,
-                boxShadow: defaultOutline_AsBoxShadow,
-            }}
             ref={ref}
+            textAlign="left"
+            justifyContent="flex-start"
             {...props}
         >
             {typeof icon === "string" ? (
-                <FAIcon iconStyle={iconStyle} icon={icon} />
+                <FAIcon iconStyle={iconStyle} icon={icon} ml={3} mr={2} />
             ) : (
                 intermingle((idx) => <span key={idx}>&nbsp;/&nbsp;</span>)(
                     icon.map(
@@ -63,6 +48,9 @@ const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
                     )
                 )
             )}
+            <chakra.span fontSize="sm" ml={1} mr={2}>
+                {label}
+            </chakra.span>
             {children}
         </Button>
     );

--- a/frontend/src/aspects/Menu/V2/MenuButton.tsx
+++ b/frontend/src/aspects/Menu/V2/MenuButton.tsx
@@ -8,17 +8,18 @@ type Props<T extends As<any> = typeof Button> = PropsOf<T> & {
     icon: string | string[];
     side: "left" | "right";
     noTooltip?: boolean;
+    showLabel: boolean;
 };
 
-function intermingle<T>(fn: (idx: number) => T) {
-    function inner(xs: ((idx: number) => T)[]) {
-        return xs.flatMap((x, i) => (i === 0 ? [x(0)] : [fn(2 * i - 1), x(2 * i)]));
-    }
-    return inner;
-}
+// function intermingle<T>(fn: (idx: number) => T) {
+//     function inner(xs: ((idx: number) => T)[]) {
+//         return xs.flatMap((x, i) => (i === 0 ? [x(0)] : [fn(2 * i - 1), x(2 * i)]));
+//     }
+//     return inner;
+// }
 
 const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
-    { label, iconStyle, icon, children, ...props }: React.PropsWithChildren<Props>,
+    { label, showLabel = true, iconStyle, icon, children, ...props }: React.PropsWithChildren<Props>,
     ref
 ): JSX.Element {
     const size = useBreakpointValue({
@@ -29,28 +30,30 @@ const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
         <Button
             aria-label={label}
             size={size}
-            p={0}
+            p={showLabel ? 0 : 2}
             minW="100%"
             ref={ref}
             textAlign="left"
-            justifyContent="flex-start"
+            justifyContent={showLabel ? "flex-start" : "center"}
             {...props}
         >
             {typeof icon === "string" ? (
-                <FAIcon iconStyle={iconStyle} icon={icon} ml={3} mr={2} />
+                <FAIcon
+                    iconStyle={iconStyle}
+                    icon={icon}
+                    w={6}
+                    ml={showLabel ? 3 : 0}
+                    mr={showLabel ? 2 : 0}
+                    textAlign="center"
+                />
             ) : (
-                intermingle((idx) => <span key={idx}>&nbsp;/&nbsp;</span>)(
-                    icon.map(
-                        (ic) =>
-                            function ButtonIcon(idx: number) {
-                                return <FAIcon key={idx} iconStyle={iconStyle} icon={ic} />;
-                            }
-                    )
-                )
+                icon.map((ic, idx) => <FAIcon key={idx} iconStyle={iconStyle} icon={ic} />)
             )}
-            <chakra.span fontSize="sm" ml={1} mr={2}>
-                {label}
-            </chakra.span>
+            {showLabel ? (
+                <chakra.span fontSize="sm" ml={1} mr={2}>
+                    {label}
+                </chakra.span>
+            ) : undefined}
             {children}
         </Button>
     );

--- a/frontend/src/aspects/Menu/V2/MenuButton.tsx
+++ b/frontend/src/aspects/Menu/V2/MenuButton.tsx
@@ -9,6 +9,7 @@ type Props<T extends As<any> = typeof Button> = PropsOf<T> & {
     side: "left" | "right";
     noTooltip?: boolean;
     showLabel: boolean;
+    ariaLabel?: string;
 };
 
 // function intermingle<T>(fn: (idx: number) => T) {
@@ -19,7 +20,7 @@ type Props<T extends As<any> = typeof Button> = PropsOf<T> & {
 // }
 
 const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
-    { label, showLabel = true, iconStyle, icon, children, ...props }: React.PropsWithChildren<Props>,
+    { ariaLabel, label, showLabel = true, iconStyle, icon, children, ...props }: React.PropsWithChildren<Props>,
     ref
 ): JSX.Element {
     const size = useBreakpointValue({
@@ -28,7 +29,7 @@ const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
     });
     return (
         <Button
-            aria-label={label}
+            aria-label={ariaLabel ?? label}
             size={size}
             p={showLabel ? 0 : 2}
             minW="100%"

--- a/frontend/src/aspects/Menu/V2/MenuButton.tsx
+++ b/frontend/src/aspects/Menu/V2/MenuButton.tsx
@@ -1,4 +1,4 @@
-import { As, Button, PropsOf, Tooltip, useBreakpointValue } from "@chakra-ui/react";
+import { As, Button, PropsOf, useBreakpointValue } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 import { defaultOutline_AsBoxShadow } from "../../Chakra/Outline";
 import { FAIcon } from "../../Icons/FAIcon";
@@ -19,7 +19,7 @@ function intermingle<T>(fn: (idx: number) => T) {
 }
 
 const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
-    { label, iconStyle, icon, side, noTooltip, children, ...props }: React.PropsWithChildren<Props>,
+    { label, iconStyle, icon, side, children, ...props }: React.PropsWithChildren<Props>,
     ref
 ): JSX.Element {
     const size = useBreakpointValue({
@@ -27,18 +27,16 @@ const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
         lg: "lg",
     });
     const expandedFontSize = useBreakpointValue({
-        base: "xl",
-        lg: "2xl",
+        base: "lg",
+        lg: "xl",
     });
-    const barWidth = useBreakpointValue({
-        base: "3.5em",
-        lg: "4em",
-    });
-    const button = (
+    return (
         <Button
             aria-label={label}
             size={size}
-            minW={barWidth}
+            color="white"
+            p={0}
+            minW="100%"
             _hover={{
                 fontSize: expandedFontSize,
                 borderLeftRadius: side === "right" ? 2 : undefined,
@@ -49,9 +47,6 @@ const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
                 borderLeftRadius: side === "right" ? 2 : undefined,
                 borderRightRadius: side === "left" ? 2 : undefined,
                 boxShadow: defaultOutline_AsBoxShadow,
-                m: "2px",
-                mr: side === "right" ? 0 : undefined,
-                ml: side === "left" ? 0 : undefined,
             }}
             ref={ref}
             {...props}
@@ -71,7 +66,6 @@ const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
             {children}
         </Button>
     );
-    return noTooltip ? button : <Tooltip label={label}>{button}</Tooltip>;
 });
 
 export default MenuButton;

--- a/frontend/src/aspects/Menu/V2/MenuButton.tsx
+++ b/frontend/src/aspects/Menu/V2/MenuButton.tsx
@@ -20,7 +20,7 @@ type Props<T extends As<any> = typeof Button> = PropsOf<T> & {
 // }
 
 const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
-    { ariaLabel, label, showLabel = true, iconStyle, icon, children, ...props }: React.PropsWithChildren<Props>,
+    { ariaLabel, label, showLabel, iconStyle, icon, children, ...props }: React.PropsWithChildren<Props>,
     ref
 ): JSX.Element {
     const size = useBreakpointValue({
@@ -31,7 +31,7 @@ const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
         <Button
             aria-label={ariaLabel ?? label}
             size={size}
-            p={showLabel ? 0 : 2}
+            p={2}
             minW="100%"
             ref={ref}
             textAlign="left"
@@ -39,22 +39,11 @@ const MenuButton = forwardRef<HTMLButtonElement, Props>(function MenuButton(
             {...props}
         >
             {typeof icon === "string" ? (
-                <FAIcon
-                    iconStyle={iconStyle}
-                    icon={icon}
-                    w={6}
-                    ml={showLabel ? 3 : 0}
-                    mr={showLabel ? 2 : 0}
-                    textAlign="center"
-                />
+                <FAIcon iconStyle={iconStyle} icon={icon} w={6} mr={showLabel ? 2 : 0} textAlign="center" />
             ) : (
                 icon.map((ic, idx) => <FAIcon key={idx} iconStyle={iconStyle} icon={ic} />)
             )}
-            {showLabel ? (
-                <chakra.span fontSize="sm" ml={1} mr={2}>
-                    {label}
-                </chakra.span>
-            ) : undefined}
+            {showLabel ? <chakra.span fontSize="sm">{label}</chakra.span> : undefined}
             {children}
         </Button>
     );

--- a/frontend/src/aspects/Menu/V2/MoreOptionsMenuButton.tsx
+++ b/frontend/src/aspects/Menu/V2/MoreOptionsMenuButton.tsx
@@ -1,4 +1,14 @@
-import { Button, ButtonProps, chakra, Menu, MenuButton, MenuList, Portal, useBreakpointValue } from "@chakra-ui/react";
+import {
+    Button,
+    ButtonProps,
+    chakra,
+    Image,
+    Menu,
+    MenuButton,
+    MenuList,
+    Portal,
+    useBreakpointValue,
+} from "@chakra-ui/react";
 import React from "react";
 import { FAIcon } from "../../Icons/FAIcon";
 
@@ -8,7 +18,8 @@ export default function MoreOptionsMenuButton({
     icon,
     side,
     children,
-    showLabel = true,
+    showLabel,
+    imageSrc,
     ...props
 }: ButtonProps & {
     label: string;
@@ -17,6 +28,7 @@ export default function MoreOptionsMenuButton({
     side: "left" | "right";
     children: React.ReactNode | React.ReactNodeArray;
     showLabel: boolean;
+    imageSrc?: string;
 }): JSX.Element {
     const size = useBreakpointValue({
         base: "md",
@@ -28,25 +40,25 @@ export default function MoreOptionsMenuButton({
                 as={Button}
                 aria-label={label}
                 size={size}
-                p={showLabel ? 0 : 2}
+                p={2}
                 minW="100%"
                 textAlign={showLabel ? "left" : "center"}
                 justifyContent={showLabel ? "flex-start" : "center"}
                 {...props}
             >
-                <FAIcon
-                    iconStyle={iconStyle}
-                    icon={icon}
-                    w={6}
-                    ml={showLabel ? 3 : 0}
-                    mr={showLabel ? 2 : 0}
-                    textAlign="center"
-                />
-                {showLabel ? (
-                    <chakra.span fontSize="sm" ml={1} mr={2}>
-                        {label}
-                    </chakra.span>
-                ) : undefined}
+                {imageSrc ? (
+                    <Image
+                        display="inline-block"
+                        title="Your profile photo"
+                        src={imageSrc}
+                        w={showLabel ? 6 : 8}
+                        mr={showLabel ? 2 : 0}
+                        borderRadius="100%"
+                    />
+                ) : (
+                    <FAIcon iconStyle={iconStyle} icon={icon} w={6} mr={showLabel ? 2 : 0} textAlign="center" />
+                )}
+                {showLabel ? <chakra.span fontSize="sm">{label}</chakra.span> : undefined}
             </MenuButton>
             <Portal>
                 <MenuList zIndex={2} maxH="100vh" overflow="auto">

--- a/frontend/src/aspects/Menu/V2/MoreOptionsMenuButton.tsx
+++ b/frontend/src/aspects/Menu/V2/MoreOptionsMenuButton.tsx
@@ -1,6 +1,5 @@
-import { Button, ButtonProps, Menu, MenuButton, MenuList, Portal, useBreakpointValue } from "@chakra-ui/react";
+import { Button, ButtonProps, chakra, Menu, MenuButton, MenuList, Portal, useBreakpointValue } from "@chakra-ui/react";
 import React from "react";
-import { defaultOutline_AsBoxShadow } from "../../Chakra/Outline";
 import { FAIcon } from "../../Icons/FAIcon";
 
 export default function MoreOptionsMenuButton({
@@ -21,39 +20,22 @@ export default function MoreOptionsMenuButton({
         base: "md",
         lg: "lg",
     });
-    const expandedFontSize = useBreakpointValue({
-        base: "lg",
-        lg: "xl",
-    });
     return (
         <Menu placement={side === "left" ? "right" : "left"} colorScheme={props.colorScheme}>
             <MenuButton
                 as={Button}
                 aria-label={label}
                 size={size}
-                color="white"
                 p={0}
                 minW="100%"
-                _hover={{
-                    fontSize: expandedFontSize,
-                    borderLeftRadius: side === "right" ? 2 : undefined,
-                    borderRightRadius: side === "left" ? 2 : undefined,
-                }}
-                _focus={{
-                    fontSize: expandedFontSize,
-                    borderLeftRadius: side === "right" ? 2 : undefined,
-                    borderRightRadius: side === "left" ? 2 : undefined,
-                    boxShadow: defaultOutline_AsBoxShadow,
-                }}
-                _active={{
-                    fontSize: expandedFontSize,
-                    borderLeftRadius: side === "right" ? 2 : undefined,
-                    borderRightRadius: side === "left" ? 2 : undefined,
-                    boxShadow: defaultOutline_AsBoxShadow,
-                }}
+                textAlign="left"
+                justifyContent="flex-start"
                 {...props}
             >
-                <FAIcon iconStyle={iconStyle} icon={icon} />
+                <FAIcon iconStyle={iconStyle} icon={icon} ml={3} mr={2} />
+                <chakra.span fontSize="sm" ml={1} mr={2}>
+                    {label}
+                </chakra.span>
             </MenuButton>
             <Portal>
                 <MenuList zIndex={2} maxH="100vh" overflow="auto">

--- a/frontend/src/aspects/Menu/V2/MoreOptionsMenuButton.tsx
+++ b/frontend/src/aspects/Menu/V2/MoreOptionsMenuButton.tsx
@@ -8,6 +8,7 @@ export default function MoreOptionsMenuButton({
     icon,
     side,
     children,
+    showLabel = true,
     ...props
 }: ButtonProps & {
     label: string;
@@ -15,6 +16,7 @@ export default function MoreOptionsMenuButton({
     icon: string;
     side: "left" | "right";
     children: React.ReactNode | React.ReactNodeArray;
+    showLabel: boolean;
 }): JSX.Element {
     const size = useBreakpointValue({
         base: "md",
@@ -26,16 +28,25 @@ export default function MoreOptionsMenuButton({
                 as={Button}
                 aria-label={label}
                 size={size}
-                p={0}
+                p={showLabel ? 0 : 2}
                 minW="100%"
-                textAlign="left"
-                justifyContent="flex-start"
+                textAlign={showLabel ? "left" : "center"}
+                justifyContent={showLabel ? "flex-start" : "center"}
                 {...props}
             >
-                <FAIcon iconStyle={iconStyle} icon={icon} ml={3} mr={2} />
-                <chakra.span fontSize="sm" ml={1} mr={2}>
-                    {label}
-                </chakra.span>
+                <FAIcon
+                    iconStyle={iconStyle}
+                    icon={icon}
+                    w={6}
+                    ml={showLabel ? 3 : 0}
+                    mr={showLabel ? 2 : 0}
+                    textAlign="center"
+                />
+                {showLabel ? (
+                    <chakra.span fontSize="sm" ml={1} mr={2}>
+                        {label}
+                    </chakra.span>
+                ) : undefined}
             </MenuButton>
             <Portal>
                 <MenuList zIndex={2} maxH="100vh" overflow="auto">

--- a/frontend/src/aspects/Menu/V2/MoreOptionsMenuButton.tsx
+++ b/frontend/src/aspects/Menu/V2/MoreOptionsMenuButton.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonProps, Menu, MenuButton, MenuList, Portal, Tooltip, useBreakpointValue } from "@chakra-ui/react";
+import { Button, ButtonProps, Menu, MenuButton, MenuList, Portal, useBreakpointValue } from "@chakra-ui/react";
 import React from "react";
 import { defaultOutline_AsBoxShadow } from "../../Chakra/Outline";
 import { FAIcon } from "../../Icons/FAIcon";
@@ -22,49 +22,39 @@ export default function MoreOptionsMenuButton({
         lg: "lg",
     });
     const expandedFontSize = useBreakpointValue({
-        base: "xl",
-        lg: "2xl",
-    });
-    const barWidth = useBreakpointValue({
-        base: "3.5em",
-        lg: "4em",
+        base: "lg",
+        lg: "xl",
     });
     return (
         <Menu placement={side === "left" ? "right" : "left"} colorScheme={props.colorScheme}>
-            <Tooltip label={label}>
-                <MenuButton
-                    as={Button}
-                    aria-label={label}
-                    size={size}
-                    minW={barWidth}
-                    _hover={{
-                        fontSize: expandedFontSize,
-                        borderLeftRadius: side === "right" ? 2 : undefined,
-                        borderRightRadius: side === "left" ? 2 : undefined,
-                    }}
-                    _focus={{
-                        fontSize: expandedFontSize,
-                        borderLeftRadius: side === "right" ? 2 : undefined,
-                        borderRightRadius: side === "left" ? 2 : undefined,
-                        boxShadow: defaultOutline_AsBoxShadow,
-                        m: "2px",
-                        mr: side === "right" ? 0 : undefined,
-                        ml: side === "left" ? 0 : undefined,
-                    }}
-                    _active={{
-                        fontSize: expandedFontSize,
-                        borderLeftRadius: side === "right" ? 2 : undefined,
-                        borderRightRadius: side === "left" ? 2 : undefined,
-                        boxShadow: defaultOutline_AsBoxShadow,
-                        m: "2px",
-                        mr: side === "right" ? 0 : undefined,
-                        ml: side === "left" ? 0 : undefined,
-                    }}
-                    {...props}
-                >
-                    <FAIcon iconStyle={iconStyle} icon={icon} />
-                </MenuButton>
-            </Tooltip>
+            <MenuButton
+                as={Button}
+                aria-label={label}
+                size={size}
+                color="white"
+                p={0}
+                minW="100%"
+                _hover={{
+                    fontSize: expandedFontSize,
+                    borderLeftRadius: side === "right" ? 2 : undefined,
+                    borderRightRadius: side === "left" ? 2 : undefined,
+                }}
+                _focus={{
+                    fontSize: expandedFontSize,
+                    borderLeftRadius: side === "right" ? 2 : undefined,
+                    borderRightRadius: side === "left" ? 2 : undefined,
+                    boxShadow: defaultOutline_AsBoxShadow,
+                }}
+                _active={{
+                    fontSize: expandedFontSize,
+                    borderLeftRadius: side === "right" ? 2 : undefined,
+                    borderRightRadius: side === "left" ? 2 : undefined,
+                    boxShadow: defaultOutline_AsBoxShadow,
+                }}
+                {...props}
+            >
+                <FAIcon iconStyle={iconStyle} icon={icon} />
+            </MenuButton>
             <Portal>
                 <MenuList zIndex={2} maxH="100vh" overflow="auto">
                     {children}

--- a/frontend/src/aspects/Menu/V2/RightMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/RightMenu.tsx
@@ -1,10 +1,11 @@
-import { Box, Flex, HStack, MenuItem, useColorMode, useColorModeValue } from "@chakra-ui/react";
+import { Box, Flex, HStack, MenuItem, useBreakpointValue, useColorMode, useColorModeValue } from "@chakra-ui/react";
 import React, { useMemo, useState } from "react";
 import { Link as ReactLink, Route, useRouteMatch } from "react-router-dom";
 import LoginButton from "../../Auth/Buttons/LoginButton";
 import LogoutButton from "../../Auth/Buttons/LogoutButton";
 import { useMaybeConference } from "../../Conference/useConference";
 import { useMaybeCurrentRegistrant } from "../../Conference/useCurrentRegistrant";
+import { useRestorableState } from "../../Generic/useRestorableState";
 import FAIcon from "../../Icons/FAIcon";
 import useMaybeCurrentUser from "../../Users/CurrentUser/useMaybeCurrentUser";
 import { useMainMenu } from "../V1/MainMenu/MainMenuState";
@@ -43,6 +44,14 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
         [maybeConference?.slug, maybeRegistrant, onRightBarClose, isVisible]
     );
     const purpleBg = useColorModeValue("purple.50", "purple.900");
+    const [_isExpanded, setIsExpanded] = useRestorableState<boolean>(
+        "RightMenu_IsExpanded",
+        true,
+        (x) => x.toString(),
+        (x) => x === "true"
+    );
+    const isExpanded = !!useBreakpointValue({ base: _isExpanded && !isRightBarOpen, "2xl": _isExpanded });
+    const isExpandedEnabled = useBreakpointValue({ base: !isRightBarOpen, "2xl": true });
     return (
         <HStack h="100%" w="100%" justifyContent="stretch" spacing={0}>
             <Box
@@ -62,9 +71,30 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                 h="100%"
                 bgColor="purple.700"
             >
+                <MenuButton
+                    label={isExpanded ? "Collapse menu" : "Expand menu"}
+                    iconStyle="s"
+                    icon={isExpanded ? ["grip-lines-vertical", "arrow-right"] : ["arrow-left", "grip-lines-vertical"]}
+                    borderTopRadius={0}
+                    colorScheme={colorScheme}
+                    side="right"
+                    mb={1}
+                    showLabel={false}
+                    onClick={() => setIsExpanded(!isExpanded)}
+                    fontSize="xs"
+                    justifyContent="center"
+                    w="auto"
+                    minW="auto"
+                    alignSelf="flex-start"
+                    minH={0}
+                    h="auto"
+                    lineHeight={0}
+                    m={1.5}
+                    isDisabled={!isExpandedEnabled}
+                />
                 {maybeUser ? (
                     <>
-                        <LogoutButton asMenuButtonV2 />
+                        <LogoutButton asMenuButtonV2 showLabel={isExpanded} />
                         <MoreOptionsMenuButton
                             label="Options"
                             iconStyle="s"
@@ -73,6 +103,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                             colorScheme={colorScheme}
                             side="right"
                             mb="auto"
+                            showLabel={isExpanded}
                         >
                             <MenuItem
                                 onClick={() => {
@@ -93,7 +124,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                         </MoreOptionsMenuButton>
                     </>
                 ) : (
-                    <LoginButton asMenuButtonV2 />
+                    <LoginButton asMenuButtonV2 showLabel={isExpanded} />
                 )}
                 {maybeConference?.slug && maybeRegistrant ? (
                     <>
@@ -110,6 +141,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                                     onRightBarOpen();
                                 }}
                                 mb={1}
+                                showLabel={isExpanded}
                             >
                                 <Box pos="absolute" top={1} right={1} fontSize="xs">
                                     {pageChatUnreadCount}
@@ -129,6 +161,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                                     onRightBarOpen();
                                 }}
                                 mb={1}
+                                showLabel={isExpanded}
                             >
                                 <Box pos="absolute" top={1} right={1} fontSize="xs">
                                     {pageChatUnreadCount}
@@ -146,6 +179,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                                     onRightBarOpen();
                                 }}
                                 mb={1}
+                                showLabel={isExpanded}
                             />
                         </Route>
                         <MenuButton
@@ -160,6 +194,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                                 onRightBarOpen();
                             }}
                             mb={1}
+                            showLabel={isExpanded}
                         >
                             <Box pos="absolute" top={1} right={1} fontSize="xs">
                                 {chatsUnreadCount}
@@ -177,6 +212,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                                 onRightBarOpen();
                             }}
                             mb="auto"
+                            showLabel={isExpanded}
                         />
                     </>
                 ) : undefined}

--- a/frontend/src/aspects/Menu/V2/RightMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/RightMenu.tsx
@@ -2,7 +2,6 @@ import { Box, Flex, HStack, MenuItem, useBreakpointValue, useColorMode, useColor
 import React, { useMemo, useState } from "react";
 import { Link as ReactLink, Route, useRouteMatch } from "react-router-dom";
 import LoginButton from "../../Auth/Buttons/LoginButton";
-import LogoutButton from "../../Auth/Buttons/LogoutButton";
 import { useMaybeConference } from "../../Conference/useConference";
 import { useMaybeCurrentRegistrant } from "../../Conference/useCurrentRegistrant";
 import { useRestorableState } from "../../Generic/useRestorableState";
@@ -94,7 +93,6 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                 />
                 {maybeUser ? (
                     <>
-                        <LogoutButton asMenuButtonV2 showLabel={isExpanded} />
                         <MoreOptionsMenuButton
                             label="Options"
                             iconStyle="s"

--- a/frontend/src/aspects/Menu/V2/RightMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/RightMenu.tsx
@@ -91,39 +91,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                     m={1.5}
                     isDisabled={!isExpandedEnabled}
                 />
-                {maybeUser ? (
-                    <>
-                        <MoreOptionsMenuButton
-                            label="Options"
-                            iconStyle="s"
-                            icon="ellipsis-h"
-                            borderTopRadius={0}
-                            colorScheme={colorScheme}
-                            side="right"
-                            mb="auto"
-                            showLabel={isExpanded}
-                        >
-                            <MenuItem
-                                onClick={() => {
-                                    colorMode.toggleColorMode();
-                                }}
-                            >
-                                <FAIcon iconStyle="s" icon="moon" />
-                                &nbsp;&nbsp;Toggle dark mode
-                            </MenuItem>
-                            <MenuItem as={ReactLink} to="/user/pushNotifications">
-                                <FAIcon iconStyle="s" icon="envelope-open-text" />
-                                &nbsp;&nbsp;Push notifications
-                            </MenuItem>
-                            {/* <MenuItem onClick={onOpenUXChoice}>
-                        <FAIcon iconStyle="s" icon="exchange-alt" />
-                        &nbsp;&nbsp;Change UI experience
-                    </MenuItem> */}
-                        </MoreOptionsMenuButton>
-                    </>
-                ) : (
-                    <LoginButton asMenuButtonV2 showLabel={isExpanded} />
-                )}
+                {!maybeUser ? <LoginButton asMenuButtonV2 showLabel={isExpanded} /> : undefined}
                 {maybeConference?.slug && maybeRegistrant ? (
                     <>
                         <Route path={`${path}/item/`}>
@@ -212,6 +180,38 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                             mb="auto"
                             showLabel={isExpanded}
                         />
+                    </>
+                ) : undefined}
+                {maybeUser ? (
+                    <>
+                        <MoreOptionsMenuButton
+                            label="Options"
+                            iconStyle="s"
+                            icon="ellipsis-h"
+                            borderTopRadius={0}
+                            colorScheme={colorScheme}
+                            side="right"
+                            showLabel={isExpanded}
+                            h="auto"
+                            pt={1.5}
+                        >
+                            <MenuItem
+                                onClick={() => {
+                                    colorMode.toggleColorMode();
+                                }}
+                            >
+                                <FAIcon iconStyle="s" icon="moon" />
+                                &nbsp;&nbsp;Toggle dark mode
+                            </MenuItem>
+                            <MenuItem as={ReactLink} to="/user/pushNotifications">
+                                <FAIcon iconStyle="s" icon="envelope-open-text" />
+                                &nbsp;&nbsp;Push notifications
+                            </MenuItem>
+                            {/* <MenuItem onClick={onOpenUXChoice}>
+                        <FAIcon iconStyle="s" icon="exchange-alt" />
+                        &nbsp;&nbsp;Change UI experience
+                    </MenuItem> */}
+                        </MoreOptionsMenuButton>
                     </>
                 ) : undefined}
             </Flex>

--- a/frontend/src/aspects/Menu/V2/RightMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/RightMenu.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, HStack, MenuItem, useBreakpointValue, useColorMode, useColorModeValue } from "@chakra-ui/react";
+import { Box, Flex, HStack, MenuItem, useColorMode, useColorModeValue } from "@chakra-ui/react";
 import React, { useMemo, useState } from "react";
 import { Link as ReactLink, Route, useRouteMatch } from "react-router-dom";
 import LoginButton from "../../Auth/Buttons/LoginButton";
@@ -13,7 +13,7 @@ import MoreOptionsMenuButton from "./MoreOptionsMenuButton";
 import { RightSidebarTabs, useRightSidebarCurrentTab } from "./RightSidebar/RightSidebarCurrentTab";
 import RightSidebarSections from "./RightSidebar/RightSidebarSections";
 
-const colorScheme = "transparent";
+const colorScheme = "purple";
 export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.Element {
     const { isRightBarOpen, onRightBarOpen, onRightBarClose } = useMainMenu();
     const maybeConference = useMaybeConference();
@@ -29,10 +29,6 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
     const [pageChatUnreadCount, setPageChatUnreadCount] = useState<string>("");
     const [chatsUnreadCount, setChatsUnreadCount] = useState<string>("");
 
-    const barWidth = useBreakpointValue({
-        base: "3em",
-        lg: "4em",
-    });
     const rightSections = useMemo(
         () =>
             maybeConference?.slug && maybeRegistrant ? (
@@ -51,8 +47,8 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
         <HStack h="100%" w="100%" justifyContent="stretch" spacing={0}>
             <Box
                 display={isRightBarOpen && maybeRegistrant ? "block" : "none"}
+                w="100%"
                 h="100%"
-                w={`calc(100% - ${barWidth})`}
                 zIndex={0}
                 bgColor={purpleBg}
             >
@@ -60,22 +56,21 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
             </Box>
             <Flex
                 flexDir="column"
-                justifyContent={maybeUser ? "center" : "flex-start"}
+                justifyContent="flex-start"
                 alignItems="flex-end"
                 zIndex={1}
-                minW={barWidth}
                 h="100%"
-                bgColor="purple.500"
+                bgColor="purple.700"
             >
                 {maybeUser ? (
                     <>
                         <LogoutButton asMenuButtonV2 />
                         <MoreOptionsMenuButton
-                            label="More options"
+                            label="Options"
                             iconStyle="s"
                             icon="ellipsis-h"
                             borderTopRadius={0}
-                            colorScheme="transparent"
+                            colorScheme={colorScheme}
                             side="right"
                             mb="auto"
                         >
@@ -104,7 +99,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                     <>
                         <Route path={`${path}/item/`}>
                             <MenuButton
-                                label="Chat for this page"
+                                label="Chat here"
                                 iconStyle="s"
                                 icon="comment"
                                 borderRadius={0}
@@ -114,6 +109,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                                     setCurrentTab(RightSidebarTabs.PageChat);
                                     onRightBarOpen();
                                 }}
+                                mb={1}
                             >
                                 <Box pos="absolute" top={1} right={1} fontSize="xs">
                                     {pageChatUnreadCount}
@@ -122,7 +118,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                         </Route>
                         <Route path={`${path}/room/`}>
                             <MenuButton
-                                label="Chat for this page"
+                                label="Chat here"
                                 iconStyle="s"
                                 icon="comment"
                                 borderRadius={0}
@@ -132,6 +128,7 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                                     setCurrentTab(RightSidebarTabs.PageChat);
                                     onRightBarOpen();
                                 }}
+                                mb={1}
                             >
                                 <Box pos="absolute" top={1} right={1} fontSize="xs">
                                     {pageChatUnreadCount}
@@ -148,10 +145,11 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                                     setCurrentTab(RightSidebarTabs.RaiseHand);
                                     onRightBarOpen();
                                 }}
+                                mb={1}
                             />
                         </Route>
                         <MenuButton
-                            label="All your chats"
+                            label="Your chats"
                             iconStyle="s"
                             icon="comments"
                             borderRadius={0}
@@ -161,13 +159,14 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                                 setCurrentTab(RightSidebarTabs.Chats);
                                 onRightBarOpen();
                             }}
+                            mb={1}
                         >
                             <Box pos="absolute" top={1} right={1} fontSize="xs">
                                 {chatsUnreadCount}
                             </Box>
                         </MenuButton>
                         <MenuButton
-                            label="Who's here with you"
+                            label="Who's here"
                             iconStyle="s"
                             icon="users"
                             borderRadius={0}

--- a/frontend/src/aspects/Menu/V2/RightMenu.tsx
+++ b/frontend/src/aspects/Menu/V2/RightMenu.tsx
@@ -1,8 +1,8 @@
-import { useAuth0 } from "@auth0/auth0-react";
-import { Box, Flex, HStack, MenuItem, Text, useBreakpointValue, useColorMode } from "@chakra-ui/react";
+import { Box, Flex, HStack, MenuItem, useBreakpointValue, useColorMode, useColorModeValue } from "@chakra-ui/react";
 import React, { useMemo, useState } from "react";
 import { Link as ReactLink, Route, useRouteMatch } from "react-router-dom";
 import LoginButton from "../../Auth/Buttons/LoginButton";
+import LogoutButton from "../../Auth/Buttons/LogoutButton";
 import { useMaybeConference } from "../../Conference/useConference";
 import { useMaybeCurrentRegistrant } from "../../Conference/useCurrentRegistrant";
 import FAIcon from "../../Icons/FAIcon";
@@ -13,7 +13,7 @@ import MoreOptionsMenuButton from "./MoreOptionsMenuButton";
 import { RightSidebarTabs, useRightSidebarCurrentTab } from "./RightSidebar/RightSidebarCurrentTab";
 import RightSidebarSections from "./RightSidebar/RightSidebarSections";
 
-const colorScheme = "purple";
+const colorScheme = "transparent";
 export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.Element {
     const { isRightBarOpen, onRightBarOpen, onRightBarClose } = useMainMenu();
     const maybeConference = useMaybeConference();
@@ -23,9 +23,6 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
 
     const colorMode = useColorMode();
     const maybeUser = useMaybeCurrentUser()?.user;
-
-    const { logout } = useAuth0();
-    const logoutReturnTo = useMemo(() => `${window.location.origin}/auth0/logged-out`, []);
 
     const { setCurrentTab } = useRightSidebarCurrentTab();
 
@@ -49,29 +46,60 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
             ) : undefined,
         [maybeConference?.slug, maybeRegistrant, onRightBarClose, isVisible]
     );
+    const purpleBg = useColorModeValue("purple.50", "purple.900");
     return (
-        <HStack h="100%" w="100%" justifyContent="stretch">
+        <HStack h="100%" w="100%" justifyContent="stretch" spacing={0}>
             <Box
                 display={isRightBarOpen && maybeRegistrant ? "block" : "none"}
                 h="100%"
                 w={`calc(100% - ${barWidth})`}
                 zIndex={0}
+                bgColor={purpleBg}
             >
                 {rightSections}
             </Box>
             <Flex
                 flexDir="column"
-                w={barWidth}
-                h={maybeUser ? undefined : "100%"}
                 justifyContent={maybeUser ? "center" : "flex-start"}
                 alignItems="flex-end"
                 zIndex={1}
+                minW={barWidth}
+                h="100%"
+                bgColor="purple.500"
             >
                 {maybeUser ? (
-                    <Text fontSize="xs" textAlign="right" mr={1} mb={2}>
-                        Participate
-                    </Text>
-                ) : undefined}
+                    <>
+                        <LogoutButton asMenuButtonV2 />
+                        <MoreOptionsMenuButton
+                            label="More options"
+                            iconStyle="s"
+                            icon="ellipsis-h"
+                            borderTopRadius={0}
+                            colorScheme="transparent"
+                            side="right"
+                            mb="auto"
+                        >
+                            <MenuItem
+                                onClick={() => {
+                                    colorMode.toggleColorMode();
+                                }}
+                            >
+                                <FAIcon iconStyle="s" icon="moon" />
+                                &nbsp;&nbsp;Toggle dark mode
+                            </MenuItem>
+                            <MenuItem as={ReactLink} to="/user/pushNotifications">
+                                <FAIcon iconStyle="s" icon="envelope-open-text" />
+                                &nbsp;&nbsp;Push notifications
+                            </MenuItem>
+                            {/* <MenuItem onClick={onOpenUXChoice}>
+                        <FAIcon iconStyle="s" icon="exchange-alt" />
+                        &nbsp;&nbsp;Change UI experience
+                    </MenuItem> */}
+                        </MoreOptionsMenuButton>
+                    </>
+                ) : (
+                    <LoginButton asMenuButtonV2 />
+                )}
                 {maybeConference?.slug && maybeRegistrant ? (
                     <>
                         <Route path={`${path}/item/`}>
@@ -149,42 +177,10 @@ export default function RightMenu({ isVisible }: { isVisible: boolean }): JSX.El
                                 setCurrentTab(RightSidebarTabs.Presence);
                                 onRightBarOpen();
                             }}
+                            mb="auto"
                         />
                     </>
                 ) : undefined}
-                {maybeUser ? (
-                    <MoreOptionsMenuButton
-                        label="More options"
-                        iconStyle="s"
-                        icon="ellipsis-h"
-                        borderTopRadius={0}
-                        colorScheme="gray"
-                        side="right"
-                    >
-                        <MenuItem
-                            onClick={() => {
-                                colorMode.toggleColorMode();
-                            }}
-                        >
-                            <FAIcon iconStyle="s" icon="moon" />
-                            &nbsp;&nbsp;Toggle dark mode
-                        </MenuItem>
-                        <MenuItem as={ReactLink} to="/user/pushNotifications">
-                            <FAIcon iconStyle="s" icon="envelope-open-text" />
-                            &nbsp;&nbsp;Push notifications
-                        </MenuItem>
-                        {/* <MenuItem onClick={onOpenUXChoice}>
-                            <FAIcon iconStyle="s" icon="exchange-alt" />
-                            &nbsp;&nbsp;Change UI experience
-                        </MenuItem> */}
-                        <MenuItem onClick={() => logout({ returnTo: logoutReturnTo })}>
-                            <FAIcon iconStyle="s" icon="sign-out-alt" />
-                            &nbsp;&nbsp;Logout
-                        </MenuItem>
-                    </MoreOptionsMenuButton>
-                ) : (
-                    <LoginButton asMenuButtonV2 />
-                )}
             </Flex>
         </HStack>
     );


### PR DESCRIPTION
## What's improved

The side menu bars now default to showing the full text of the item names. They have full-height distinctive colours and can be expanded/contracted to show/hide the labels. On smaller screens, the right-bar labels automatically hide when the chat is opened. 

The chat panel now resizes according to the screensize to offer greater flexibility/compatibility. It also has a purple background colour to signify its assocation with the right menu bar and distinguish from the page content. 

The left menu buttons are now divided into two groups: the main navigation buttons are centered (with the home button coming first rather than last); the secondary nav buttons (manage conference, switch conference, feedback) are grouped at the bottom. The right menu bar is similarly split, but top-group and center-group, placing the login/out and options buttons in the top group.

The button tooltips - which frequently became stuck and got in the way - are now removed since they aren't needed.

The Program button icon is just a calendar now, removing the search icon which seemed to confuse people more than anything.

The Socialise modal heading is removed and the tab styling is made to match the Program modal.

## Details

All of these changes have been motivated by user feedback over the last month, as well as input from UX/UI experts.

## Upgrading / Deployment

Only the frontend needs building/deploying.