### PR TITLE
Increase AWS MediaPackage HLS segment duration

### DIFF
--- a/services/playout/src/channel-stack/channel-stack/channelStack.ts
+++ b/services/playout/src/channel-stack/channel-stack/channelStack.ts
@@ -302,7 +302,7 @@ export class ChannelStack extends cdk.Stack {
                 playlistType: PlaylistType.EVENT,
                 playlistWindowSeconds: 60,
                 programDateTimeIntervalSeconds: 10,
-                segmentDurationSeconds: 1,
+                segmentDurationSeconds: 5,
                 streamSelection: {
                     maxVideoBitsPerSecond: 2147483647,
                     minVideoBitsPerSecond: 0,


### PR DESCRIPTION
To reduce the probability of triggering [the VideoJS segment buffering bug](https://github.com/videojs/http-streaming/issues/1000#issuecomment-899934566)

## What's improved

By increasing the segment duration from 1s to 5s, we hopefully reduce the probability of triggering the VideoJS client-side segment buffering bug by ~5x. Assuming probability works at scale the way I hope (and there are no other unintended side effects), this should dramatically reduce the impact on our end users while we wait for VideoJS to come up with a proper fix.

## Details

- [Related issue on VideoJS HTTP Streaming](https://github.com/videojs/http-streaming/issues/1000#issuecomment-899934566)

## Upgrading and Deployment

Instructions for how to deploy these changes to production. Please tick (i.e.
put an 'x' in) the boxes for the actions that are necessary.

- [ ] Apply migrations to Hasura
- [ ] Apply metadata to Hasura
- [ ] Reload enum table/values in Hasura for [table names]
- [ ] Re-deploy frontend
- [ ] Re-deploy actions service
- [x] Re-deploy playout service
- [ ] Re-deploy real-time service
- [ ] Flush real-time service state (Redis/RabbitMQ)
- [ ] Update environment variables for [name of component]

Any other steps necessary to re-deploy?

I honestly am not sure - I think any existing MediaLive endpoints probably have to be deleted so they can be recreated?
