### PR TITLE
Improvement/hidden exhibitions

### DIFF
--- a/frontend/codegen.js
+++ b/frontend/codegen.js
@@ -10,7 +10,11 @@ module.exports = {
             },
         },
     ],
-    documents: ["./src/**/*.tsx", "./src/**/*.ts"],
+    documents: [
+        "./src/aspects/**/*.tsx", "./src/aspects/**/*.ts",
+        "./src/types/**/*.tsx", "./src/types/**/*.ts",
+        "./src/*.tsx", "./src/*.ts"
+    ],
     overwrite: true,
     generates: {
         "./src/generated/graphql.tsx": {

--- a/frontend/src/aspects/Conference/Attend/Exhibition/ExhibitionsPage.tsx
+++ b/frontend/src/aspects/Conference/Attend/Exhibition/ExhibitionsPage.tsx
@@ -47,7 +47,7 @@ gql`
     }
 
     query SelectAllExhibitions($conferenceId: uuid!) {
-        collection_Exhibition(where: { conferenceId: { _eq: $conferenceId } }) {
+        collection_Exhibition(where: { conferenceId: { _eq: $conferenceId }, isHidden: { _eq: false } }) {
             ...ExhibitionSummary
         }
     }
@@ -60,10 +60,10 @@ function ExhibitionTile({ exhibition }: { exhibition: ExhibitionSummaryFragment 
     const { colorMode } = useColorMode();
     const baseBgColour = colorMode === "light" ? "gray.200" : "gray.600";
     const baseGrey = useToken("colors", baseBgColour);
-    const baseColour = useMemo(() => (Color(exhibition.colour).getAlpha() !== 0 ? exhibition.colour : baseGrey), [
-        baseGrey,
-        exhibition.colour,
-    ]);
+    const baseColour = useMemo(
+        () => (Color(exhibition.colour).getAlpha() !== 0 ? exhibition.colour : baseGrey),
+        [baseGrey, exhibition.colour]
+    );
     const bgColour = useMemo(() => Color(baseColour), [baseColour]);
     const bgColour_Hover = useMemo(
         () => (colorMode === "light" ? Color(baseColour).darken(15) : Color(baseColour).lighten(15)),

--- a/frontend/src/aspects/Conference/Manage/Content/Functions.ts
+++ b/frontend/src/aspects/Conference/Manage/Content/Functions.ts
@@ -57,6 +57,7 @@ export function convertContentToDescriptors(allContent: SelectAllContentQuery): 
                     colour: data.colour,
                     name: data.name,
                     priority: data.priority,
+                    isHidden: data.isHidden,
                 },
             ])
         ),

--- a/frontend/src/aspects/Conference/Manage/Content/ManageContent.tsx
+++ b/frontend/src/aspects/Conference/Manage/Content/ManageContent.tsx
@@ -234,6 +234,7 @@ gql`
         name
         colour
         priority
+        isHidden
     }
 
     query ManageContent_SelectAllExhibitions($conferenceId: uuid!) {

--- a/frontend/src/aspects/Conference/Manage/Content/Types.ts
+++ b/frontend/src/aspects/Conference/Manage/Content/Types.ts
@@ -15,6 +15,7 @@ export type ExhibitionDescriptor = {
     name: string;
     colour: string;
     priority: number;
+    isHidden: boolean;
 };
 
 export type ElementDescriptor = {

--- a/frontend/src/aspects/Conference/Manage/Content/useSaveContentDiff.ts
+++ b/frontend/src/aspects/Conference/Manage/Content/useSaveContentDiff.ts
@@ -153,6 +153,7 @@ gql`
         colour
         name
         priority
+        isHidden
     }
 
     query SelectAllContent($conferenceId: uuid!) {
@@ -417,10 +418,10 @@ gql`
         }
     }
 
-    mutation UpdateExhibition($id: uuid!, $name: String!, $colour: String!, $priority: Int!) {
+    mutation UpdateExhibition($id: uuid!, $name: String!, $colour: String!, $priority: Int!, $isHidden: Boolean!) {
         update_collection_Exhibition_by_pk(
             pk_columns: { id: $id }
-            _set: { name: $name, colour: $colour, priority: $priority }
+            _set: { name: $name, colour: $colour, priority: $priority, isHidden: $isHidden }
         ) {
             ...ExhibitionInfo
         }
@@ -808,6 +809,7 @@ export function useSaveContentDiff():
                                         name: exhibition.name,
                                         colour: exhibition.colour,
                                         priority: exhibition.priority,
+                                        isHidden: exhibition.isHidden,
                                     })
                                 ),
                             },
@@ -827,6 +829,7 @@ export function useSaveContentDiff():
                                         name: exhibition.name,
                                         colour: exhibition.colour,
                                         priority: exhibition.priority,
+                                        isHidden: exhibition.isHidden,
                                     },
                                 });
                                 ok = true;

--- a/frontend/src/aspects/Conference/Manage/Content/v2/Exhibition/ManageExhibitionsModal.tsx
+++ b/frontend/src/aspects/Conference/Manage/Content/v2/Exhibition/ManageExhibitionsModal.tsx
@@ -2,6 +2,8 @@ import { gql, Reference } from "@apollo/client";
 import {
     Box,
     Button,
+    Center,
+    Checkbox,
     FormLabel,
     Input,
     Modal,
@@ -36,7 +38,11 @@ import {
     useManageContent_SelectAllExhibitionsQuery,
     useManageContent_UpdateExhibitionMutation,
 } from "../../../../../../generated/graphql";
-import { NumberRangeColumnFilter, TextColumnFilter } from "../../../../../CRUDTable2/CRUDComponents";
+import {
+    CheckBoxColumnFilter,
+    NumberRangeColumnFilter,
+    TextColumnFilter,
+} from "../../../../../CRUDTable2/CRUDComponents";
 import CRUDTable, {
     CellProps,
     ColumnHeaderProps,
@@ -256,13 +262,47 @@ function ManageExhibitionsModalBody(): JSX.Element {
                     );
                 },
             },
+            {
+                id: "isHidden",
+                header: function Header(props: ColumnHeaderProps<ManageContent_ExhibitionFragment>) {
+                    return props.isInCreate ? (
+                        <FormLabel>Hidden?</FormLabel>
+                    ) : (
+                        <Button size="xs" onClick={props.onClick}>
+                            Hidden?{props.sortDir !== null ? ` ${props.sortDir}` : undefined}
+                        </Button>
+                    );
+                },
+                get: (data) => data.isHidden,
+                set: (data, value: boolean) => {
+                    data.isHidden = value;
+                },
+                sort: (x: boolean, y: boolean) => (x && y ? 0 : x ? -1 : y ? 1 : 0),
+                filterFn: (rows: Array<ManageContent_ExhibitionFragment>, filterValue: boolean) => {
+                    return rows.filter((row) => !!row.isHidden === filterValue);
+                },
+                filterEl: CheckBoxColumnFilter,
+                cell: function Cell(props: CellProps<Partial<ManageContent_ExhibitionFragment>, boolean>) {
+                    return (
+                        <Center>
+                            <Checkbox
+                                isChecked={props.value ?? false}
+                                onChange={(ev) => props.onChange?.(ev.target.checked)}
+                                onBlur={props.onBlur}
+                                ref={props.ref as LegacyRef<HTMLInputElement>}
+                            />
+                        </Center>
+                    );
+                },
+            },
         ];
         return result;
     }, [colorMode]);
 
-    const data = useMemo(() => [...(exhibitionsResponse.data?.collection_Exhibition ?? [])], [
-        exhibitionsResponse.data?.collection_Exhibition,
-    ]);
+    const data = useMemo(
+        () => [...(exhibitionsResponse.data?.collection_Exhibition ?? [])],
+        [exhibitionsResponse.data?.collection_Exhibition]
+    );
 
     const {
         isOpen: isSecondaryPanelOpen,
@@ -315,6 +355,7 @@ function ManageExhibitionsModalBody(): JSX.Element {
                     name: "",
                     colour: "rgba(0,0,0,0)",
                     priority: data?.length ?? 0,
+                    isHidden: false,
                 } as ManageContent_ExhibitionFragment),
             makeWhole: (d) => d as ManageContent_ExhibitionFragment,
             start: (record) => {
@@ -326,6 +367,7 @@ function ManageExhibitionsModalBody(): JSX.Element {
                             name: record.name,
                             colour: record.colour,
                             priority: record.priority,
+                            isHidden: record.isHidden,
                         },
                     },
                     update: (cache, response) => {
@@ -368,6 +410,7 @@ function ManageExhibitionsModalBody(): JSX.Element {
                     name: record.name,
                     colour: record.colour,
                     priority: record.priority,
+                    isHidden: record.isHidden,
                 };
                 updateExhibition({
                     variables: {

--- a/frontend/src/aspects/Conference/Manage/Import/Content/ImportContentPage.tsx
+++ b/frontend/src/aspects/Conference/Manage/Import/Content/ImportContentPage.tsx
@@ -207,7 +207,8 @@ const presetJSONata_CSVQuery_Exhibitions = `
     "exhibitions": [$.{
         "name": $.Name,
         "priority": $number($.Priority),
-        "colour": $.Colour
+        "colour": $.Colour,
+        "isHidden": $.Hidden
     }],
     "tags": [],
     "people": []

--- a/frontend/src/aspects/Conference/Manage/Import/Content/MergeContent.ts
+++ b/frontend/src/aspects/Conference/Manage/Import/Content/MergeContent.ts
@@ -31,7 +31,6 @@ import {
     isMatch_Id,
     isMatch_Id_Generalised,
     isMatch_OriginatingDataId,
-    isMatch_String_EditDistance,
     isMatch_String_Exact,
     mergeFieldInPlace,
     mergeIdInPlace,
@@ -602,6 +601,7 @@ function convertExhibition(
         name: element.name,
         colour: element.colour ?? "rgba(0,0,0,0)",
         priority: element.priority ?? 0,
+        isHidden: element.isHidden ?? false,
     } as ExhibitionDescriptor;
 
     return result;
@@ -624,6 +624,7 @@ function mergeExhibition(
     mergeFieldInPlace(context, changes, result, "name", element1, element2);
     mergeFieldInPlace(context, changes, result, "colour", element1, element2);
     mergeFieldInPlace(context, changes, result, "priority", element1, element2);
+    mergeFieldInPlace(context, changes, result, "isHidden", element1, element2);
 
     changes.push({
         location: "Exhibition",
@@ -646,8 +647,7 @@ function findExistingExhibition(
 ): number | undefined {
     return (
         findMatch(ctx, elements, element, isMatch_Id("Exhibition")) ??
-        findMatch(ctx, elements, element, isMatch_String_Exact("name")) ??
-        findMatch(ctx, elements, element, isMatch_String_EditDistance("name"))
+        findMatch(ctx, elements, element, isMatch_String_Exact("name"))
     );
 }
 

--- a/frontend/src/aspects/Conference/Manage/Schedule/Functions.ts
+++ b/frontend/src/aspects/Conference/Manage/Schedule/Functions.ts
@@ -4,9 +4,7 @@ import type { ExhibitionDescriptor, ItemDescriptor, ProgramPersonDescriptor } fr
 import type { OriginatingDataDescriptor, OriginatingDataPart, TagDescriptor } from "../Shared/Types";
 import type { EventDescriptor, RoomDescriptor } from "./Types";
 
-export function convertScheduleToDescriptors(
-    schedule: SelectWholeScheduleQuery
-): {
+export function convertScheduleToDescriptors(schedule: SelectWholeScheduleQuery): {
     rooms: Map<string, RoomDescriptor>;
     events: Map<string, EventDescriptor>;
     tags: Map<string, TagDescriptor>;
@@ -54,6 +52,7 @@ export function convertScheduleToDescriptors(
                     colour: tag.colour,
                     name: tag.name,
                     priority: tag.priority,
+                    isHidden: tag.isHidden,
                 },
             ])
         ),

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -6082,6 +6082,7 @@ export type Collection_Exhibition = {
   readonly conferenceId: Scalars['uuid'];
   readonly created_at: Scalars['timestamptz'];
   readonly id: Scalars['uuid'];
+  readonly isHidden: Scalars['Boolean'];
   /** An array relationship */
   readonly items: ReadonlyArray<Content_ItemExhibition>;
   /** An aggregate relationship */
@@ -6184,6 +6185,7 @@ export type Collection_Exhibition_Bool_Exp = {
   readonly conferenceId?: Maybe<Uuid_Comparison_Exp>;
   readonly created_at?: Maybe<Timestamptz_Comparison_Exp>;
   readonly id?: Maybe<Uuid_Comparison_Exp>;
+  readonly isHidden?: Maybe<Boolean_Comparison_Exp>;
   readonly items?: Maybe<Content_ItemExhibition_Bool_Exp>;
   readonly name?: Maybe<String_Comparison_Exp>;
   readonly priority?: Maybe<Int_Comparison_Exp>;
@@ -6210,6 +6212,7 @@ export type Collection_Exhibition_Insert_Input = {
   readonly conferenceId?: Maybe<Scalars['uuid']>;
   readonly created_at?: Maybe<Scalars['timestamptz']>;
   readonly id?: Maybe<Scalars['uuid']>;
+  readonly isHidden?: Maybe<Scalars['Boolean']>;
   readonly items?: Maybe<Content_ItemExhibition_Arr_Rel_Insert_Input>;
   readonly name?: Maybe<Scalars['String']>;
   readonly priority?: Maybe<Scalars['Int']>;
@@ -6292,6 +6295,7 @@ export type Collection_Exhibition_Order_By = {
   readonly conferenceId?: Maybe<Order_By>;
   readonly created_at?: Maybe<Order_By>;
   readonly id?: Maybe<Order_By>;
+  readonly isHidden?: Maybe<Order_By>;
   readonly items_aggregate?: Maybe<Content_ItemExhibition_Aggregate_Order_By>;
   readonly name?: Maybe<Order_By>;
   readonly priority?: Maybe<Order_By>;
@@ -6314,6 +6318,8 @@ export enum Collection_Exhibition_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
+  IsHidden = 'isHidden',
+  /** column name */
   Name = 'name',
   /** column name */
   Priority = 'priority',
@@ -6327,6 +6333,7 @@ export type Collection_Exhibition_Set_Input = {
   readonly conferenceId?: Maybe<Scalars['uuid']>;
   readonly created_at?: Maybe<Scalars['timestamptz']>;
   readonly id?: Maybe<Scalars['uuid']>;
+  readonly isHidden?: Maybe<Scalars['Boolean']>;
   readonly name?: Maybe<Scalars['String']>;
   readonly priority?: Maybe<Scalars['Int']>;
   readonly updated_at?: Maybe<Scalars['timestamptz']>;
@@ -6386,6 +6393,8 @@ export enum Collection_Exhibition_Update_Column {
   CreatedAt = 'created_at',
   /** column name */
   Id = 'id',
+  /** column name */
+  IsHidden = 'isHidden',
   /** column name */
   Name = 'name',
   /** column name */
@@ -35794,14 +35803,14 @@ export type ManageContent_SelectAllTagsQueryVariables = Exact<{
 
 export type ManageContent_SelectAllTagsQuery = { readonly __typename?: 'query_root', readonly collection_Tag: ReadonlyArray<{ readonly __typename?: 'collection_Tag', readonly id: any, readonly conferenceId: any, readonly name: string, readonly colour: string, readonly priority: number }> };
 
-export type ManageContent_ExhibitionFragment = { readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly name: string, readonly colour: string, readonly priority: number };
+export type ManageContent_ExhibitionFragment = { readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly name: string, readonly colour: string, readonly priority: number, readonly isHidden: boolean };
 
 export type ManageContent_SelectAllExhibitionsQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
 }>;
 
 
-export type ManageContent_SelectAllExhibitionsQuery = { readonly __typename?: 'query_root', readonly collection_Exhibition: ReadonlyArray<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly name: string, readonly colour: string, readonly priority: number }> };
+export type ManageContent_SelectAllExhibitionsQuery = { readonly __typename?: 'query_root', readonly collection_Exhibition: ReadonlyArray<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly name: string, readonly colour: string, readonly priority: number, readonly isHidden: boolean }> };
 
 export type UploaderInfoFragment = { readonly __typename?: 'content_Uploader', readonly id: any, readonly conferenceId: any, readonly email: string, readonly emailsSentCount: number, readonly name: string, readonly elementId: any };
 
@@ -35821,14 +35830,14 @@ export type ItemFullNestedInfoFragment = { readonly __typename?: 'content_Item',
 
 export type TagInfoFragment = { readonly __typename?: 'collection_Tag', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly priority: number };
 
-export type ExhibitionInfoFragment = { readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly priority: number };
+export type ExhibitionInfoFragment = { readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly priority: number, readonly isHidden: boolean };
 
 export type SelectAllContentQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
 }>;
 
 
-export type SelectAllContentQuery = { readonly __typename?: 'query_root', readonly content_Item: ReadonlyArray<{ readonly __typename?: 'content_Item', readonly id: any, readonly conferenceId: any, readonly typeName: Content_ItemType_Enum, readonly title: string, readonly shortTitle?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly conferenceId: any, readonly itemId: any, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly id: any, readonly isHidden: boolean, readonly layoutData?: Maybe<any>, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly conferenceId: any, readonly email: string, readonly emailsSentCount: number, readonly name: string, readonly elementId: any }> }>, readonly itemTags: ReadonlyArray<{ readonly __typename?: 'content_ItemTag', readonly id: any, readonly tagId: any, readonly itemId: any }>, readonly itemExhibitions: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly itemId: any, readonly exhibitionId: any, readonly conferenceId: any, readonly priority?: Maybe<number>, readonly layout?: Maybe<any> }>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly conferenceId: any, readonly itemId: any, readonly personId: any, readonly priority?: Maybe<number>, readonly roleName: string }>, readonly rooms: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly id: any }> }>, readonly collection_ProgramPerson: ReadonlyArray<{ readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly conferenceId: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly registrantId?: Maybe<any> }>, readonly conference_OriginatingData: ReadonlyArray<{ readonly __typename?: 'conference_OriginatingData', readonly id: any, readonly conferenceId: any, readonly sourceId: string, readonly data?: Maybe<any> }>, readonly collection_Tag: ReadonlyArray<{ readonly __typename?: 'collection_Tag', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly priority: number }>, readonly collection_Exhibition: ReadonlyArray<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly priority: number }> };
+export type SelectAllContentQuery = { readonly __typename?: 'query_root', readonly content_Item: ReadonlyArray<{ readonly __typename?: 'content_Item', readonly id: any, readonly conferenceId: any, readonly typeName: Content_ItemType_Enum, readonly title: string, readonly shortTitle?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly conferenceId: any, readonly itemId: any, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly id: any, readonly isHidden: boolean, readonly layoutData?: Maybe<any>, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly conferenceId: any, readonly email: string, readonly emailsSentCount: number, readonly name: string, readonly elementId: any }> }>, readonly itemTags: ReadonlyArray<{ readonly __typename?: 'content_ItemTag', readonly id: any, readonly tagId: any, readonly itemId: any }>, readonly itemExhibitions: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly itemId: any, readonly exhibitionId: any, readonly conferenceId: any, readonly priority?: Maybe<number>, readonly layout?: Maybe<any> }>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly conferenceId: any, readonly itemId: any, readonly personId: any, readonly priority?: Maybe<number>, readonly roleName: string }>, readonly rooms: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly id: any }> }>, readonly collection_ProgramPerson: ReadonlyArray<{ readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly conferenceId: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly registrantId?: Maybe<any> }>, readonly conference_OriginatingData: ReadonlyArray<{ readonly __typename?: 'conference_OriginatingData', readonly id: any, readonly conferenceId: any, readonly sourceId: string, readonly data?: Maybe<any> }>, readonly collection_Tag: ReadonlyArray<{ readonly __typename?: 'collection_Tag', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly priority: number }>, readonly collection_Exhibition: ReadonlyArray<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly priority: number, readonly isHidden: boolean }> };
 
 export type InsertDeleteItemsMutationVariables = Exact<{
   newGroups: ReadonlyArray<Content_Item_Insert_Input> | Content_Item_Insert_Input;
@@ -35871,7 +35880,7 @@ export type InsertExhibitionsMutationVariables = Exact<{
 }>;
 
 
-export type InsertExhibitionsMutation = { readonly __typename?: 'mutation_root', readonly insert_collection_Exhibition?: Maybe<{ readonly __typename?: 'collection_Exhibition_mutation_response', readonly returning: ReadonlyArray<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly priority: number }> }> };
+export type InsertExhibitionsMutation = { readonly __typename?: 'mutation_root', readonly insert_collection_Exhibition?: Maybe<{ readonly __typename?: 'collection_Exhibition_mutation_response', readonly returning: ReadonlyArray<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly priority: number, readonly isHidden: boolean }> }> };
 
 export type DeleteTagsMutationVariables = Exact<{
   deleteTagIds: ReadonlyArray<Scalars['uuid']> | Scalars['uuid'];
@@ -35991,10 +36000,11 @@ export type UpdateExhibitionMutationVariables = Exact<{
   name: Scalars['String'];
   colour: Scalars['String'];
   priority: Scalars['Int'];
+  isHidden: Scalars['Boolean'];
 }>;
 
 
-export type UpdateExhibitionMutation = { readonly __typename?: 'mutation_root', readonly update_collection_Exhibition_by_pk?: Maybe<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly priority: number }> };
+export type UpdateExhibitionMutation = { readonly __typename?: 'mutation_root', readonly update_collection_Exhibition_by_pk?: Maybe<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly priority: number, readonly isHidden: boolean }> };
 
 export type CombineVideosModal_CreateCombineVideosJobMutationVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -36113,7 +36123,7 @@ export type ManageContent_InsertExhibitionMutationVariables = Exact<{
 }>;
 
 
-export type ManageContent_InsertExhibitionMutation = { readonly __typename?: 'mutation_root', readonly insert_collection_Exhibition_one?: Maybe<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly name: string, readonly colour: string, readonly priority: number }> };
+export type ManageContent_InsertExhibitionMutation = { readonly __typename?: 'mutation_root', readonly insert_collection_Exhibition_one?: Maybe<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly name: string, readonly colour: string, readonly priority: number, readonly isHidden: boolean }> };
 
 export type ManageContent_UpdateExhibitionMutationVariables = Exact<{
   id: Scalars['uuid'];
@@ -36121,7 +36131,7 @@ export type ManageContent_UpdateExhibitionMutationVariables = Exact<{
 }>;
 
 
-export type ManageContent_UpdateExhibitionMutation = { readonly __typename?: 'mutation_root', readonly update_collection_Exhibition_by_pk?: Maybe<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly name: string, readonly colour: string, readonly priority: number }> };
+export type ManageContent_UpdateExhibitionMutation = { readonly __typename?: 'mutation_root', readonly update_collection_Exhibition_by_pk?: Maybe<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly name: string, readonly colour: string, readonly priority: number, readonly isHidden: boolean }> };
 
 export type ManageContent_DeleteExhibitionsMutationVariables = Exact<{
   ids: ReadonlyArray<Scalars['uuid']> | Scalars['uuid'];
@@ -36887,7 +36897,7 @@ export type SelectWholeScheduleQueryVariables = Exact<{
 }>;
 
 
-export type SelectWholeScheduleQuery = { readonly __typename?: 'query_root', readonly room_Room: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly capacity?: Maybe<number>, readonly conferenceId: any, readonly currentModeName: Room_Mode_Enum, readonly id: any, readonly name: string, readonly priority: number, readonly originatingDataId?: Maybe<any>, readonly originatingEventId?: Maybe<any>, readonly originatingItemId?: Maybe<any>, readonly managementModeName: Room_ManagementMode_Enum, readonly originatingData?: Maybe<{ readonly __typename?: 'conference_OriginatingData', readonly id: any, readonly conferenceId: any, readonly sourceId: string, readonly data?: Maybe<any> }>, readonly participants: ReadonlyArray<{ readonly __typename?: 'room_Participant', readonly registrantId: any, readonly conferenceId: any, readonly id: any, readonly roomId: any }> }>, readonly schedule_Event: ReadonlyArray<{ readonly __typename?: 'schedule_Event', readonly conferenceId: any, readonly id: any, readonly durationSeconds: number, readonly intendedRoomModeName: Room_Mode_Enum, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly roomId: any, readonly startTime: any, readonly endTime?: Maybe<any>, readonly itemId?: Maybe<any>, readonly exhibitionId?: Maybe<any>, readonly shufflePeriodId?: Maybe<any>, readonly eventPeople: ReadonlyArray<{ readonly __typename?: 'schedule_EventProgramPerson', readonly id: any, readonly eventId: any, readonly roleName: Schedule_EventProgramPersonRole_Enum, readonly personId: any }>, readonly eventTags: ReadonlyArray<{ readonly __typename?: 'schedule_EventTag', readonly eventId: any, readonly id: any, readonly tagId: any }> }>, readonly conference_OriginatingData: ReadonlyArray<{ readonly __typename?: 'conference_OriginatingData', readonly id: any, readonly conferenceId: any, readonly sourceId: string, readonly data?: Maybe<any> }>, readonly collection_Tag: ReadonlyArray<{ readonly __typename?: 'collection_Tag', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly priority: number }>, readonly collection_Exhibition: ReadonlyArray<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly priority: number }>, readonly content_Item: ReadonlyArray<{ readonly __typename?: 'content_Item', readonly id: any, readonly conferenceId: any, readonly typeName: Content_ItemType_Enum, readonly title: string, readonly shortTitle?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly conferenceId: any, readonly itemId: any, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly id: any, readonly isHidden: boolean, readonly layoutData?: Maybe<any>, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly conferenceId: any, readonly email: string, readonly emailsSentCount: number, readonly name: string, readonly elementId: any }> }>, readonly itemTags: ReadonlyArray<{ readonly __typename?: 'content_ItemTag', readonly id: any, readonly tagId: any, readonly itemId: any }>, readonly itemExhibitions: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly itemId: any, readonly exhibitionId: any, readonly conferenceId: any, readonly priority?: Maybe<number>, readonly layout?: Maybe<any> }>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly conferenceId: any, readonly itemId: any, readonly personId: any, readonly priority?: Maybe<number>, readonly roleName: string }>, readonly rooms: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly id: any }> }>, readonly collection_ProgramPerson: ReadonlyArray<{ readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly conferenceId: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly registrantId?: Maybe<any> }> };
+export type SelectWholeScheduleQuery = { readonly __typename?: 'query_root', readonly room_Room: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly capacity?: Maybe<number>, readonly conferenceId: any, readonly currentModeName: Room_Mode_Enum, readonly id: any, readonly name: string, readonly priority: number, readonly originatingDataId?: Maybe<any>, readonly originatingEventId?: Maybe<any>, readonly originatingItemId?: Maybe<any>, readonly managementModeName: Room_ManagementMode_Enum, readonly originatingData?: Maybe<{ readonly __typename?: 'conference_OriginatingData', readonly id: any, readonly conferenceId: any, readonly sourceId: string, readonly data?: Maybe<any> }>, readonly participants: ReadonlyArray<{ readonly __typename?: 'room_Participant', readonly registrantId: any, readonly conferenceId: any, readonly id: any, readonly roomId: any }> }>, readonly schedule_Event: ReadonlyArray<{ readonly __typename?: 'schedule_Event', readonly conferenceId: any, readonly id: any, readonly durationSeconds: number, readonly intendedRoomModeName: Room_Mode_Enum, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly roomId: any, readonly startTime: any, readonly endTime?: Maybe<any>, readonly itemId?: Maybe<any>, readonly exhibitionId?: Maybe<any>, readonly shufflePeriodId?: Maybe<any>, readonly eventPeople: ReadonlyArray<{ readonly __typename?: 'schedule_EventProgramPerson', readonly id: any, readonly eventId: any, readonly roleName: Schedule_EventProgramPersonRole_Enum, readonly personId: any }>, readonly eventTags: ReadonlyArray<{ readonly __typename?: 'schedule_EventTag', readonly eventId: any, readonly id: any, readonly tagId: any }> }>, readonly conference_OriginatingData: ReadonlyArray<{ readonly __typename?: 'conference_OriginatingData', readonly id: any, readonly conferenceId: any, readonly sourceId: string, readonly data?: Maybe<any> }>, readonly collection_Tag: ReadonlyArray<{ readonly __typename?: 'collection_Tag', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly priority: number }>, readonly collection_Exhibition: ReadonlyArray<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly conferenceId: any, readonly colour: string, readonly name: string, readonly priority: number, readonly isHidden: boolean }>, readonly content_Item: ReadonlyArray<{ readonly __typename?: 'content_Item', readonly id: any, readonly conferenceId: any, readonly typeName: Content_ItemType_Enum, readonly title: string, readonly shortTitle?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly conferenceId: any, readonly itemId: any, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly id: any, readonly isHidden: boolean, readonly layoutData?: Maybe<any>, readonly name: string, readonly originatingDataId?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly conferenceId: any, readonly email: string, readonly emailsSentCount: number, readonly name: string, readonly elementId: any }> }>, readonly itemTags: ReadonlyArray<{ readonly __typename?: 'content_ItemTag', readonly id: any, readonly tagId: any, readonly itemId: any }>, readonly itemExhibitions: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly itemId: any, readonly exhibitionId: any, readonly conferenceId: any, readonly priority?: Maybe<number>, readonly layout?: Maybe<any> }>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly conferenceId: any, readonly itemId: any, readonly personId: any, readonly priority?: Maybe<number>, readonly roleName: string }>, readonly rooms: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly id: any }> }>, readonly collection_ProgramPerson: ReadonlyArray<{ readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly conferenceId: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly registrantId?: Maybe<any> }> };
 
 export type InsertRoomsMutationVariables = Exact<{
   newRooms: ReadonlyArray<Room_Room_Insert_Input> | Room_Room_Insert_Input;
@@ -38341,6 +38351,7 @@ export const ManageContent_ExhibitionFragmentDoc = gql`
   name
   colour
   priority
+  isHidden
 }
     `;
 export const ProgramPersonInfoFragmentDoc = gql`
@@ -38457,6 +38468,7 @@ export const ExhibitionInfoFragmentDoc = gql`
   colour
   name
   priority
+  isHidden
 }
     `;
 export const SEoUm_ElementFragmentDoc = gql`
@@ -39868,7 +39880,9 @@ export type SelectExhibitionLazyQueryHookResult = ReturnType<typeof useSelectExh
 export type SelectExhibitionQueryResult = Apollo.QueryResult<SelectExhibitionQuery, SelectExhibitionQueryVariables>;
 export const SelectAllExhibitionsDocument = gql`
     query SelectAllExhibitions($conferenceId: uuid!) {
-  collection_Exhibition(where: {conferenceId: {_eq: $conferenceId}}) {
+  collection_Exhibition(
+    where: {conferenceId: {_eq: $conferenceId}, isHidden: {_eq: false}}
+  ) {
     ...ExhibitionSummary
   }
 }
@@ -43655,10 +43669,10 @@ export type UpdateTagMutationHookResult = ReturnType<typeof useUpdateTagMutation
 export type UpdateTagMutationResult = Apollo.MutationResult<UpdateTagMutation>;
 export type UpdateTagMutationOptions = Apollo.BaseMutationOptions<UpdateTagMutation, UpdateTagMutationVariables>;
 export const UpdateExhibitionDocument = gql`
-    mutation UpdateExhibition($id: uuid!, $name: String!, $colour: String!, $priority: Int!) {
+    mutation UpdateExhibition($id: uuid!, $name: String!, $colour: String!, $priority: Int!, $isHidden: Boolean!) {
   update_collection_Exhibition_by_pk(
     pk_columns: {id: $id}
-    _set: {name: $name, colour: $colour, priority: $priority}
+    _set: {name: $name, colour: $colour, priority: $priority, isHidden: $isHidden}
   ) {
     ...ExhibitionInfo
   }
@@ -43683,6 +43697,7 @@ export type UpdateExhibitionMutationFn = Apollo.MutationFunction<UpdateExhibitio
  *      name: // value for 'name'
  *      colour: // value for 'colour'
  *      priority: // value for 'priority'
+ *      isHidden: // value for 'isHidden'
  *   },
  * });
  */

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -1111,6 +1111,7 @@
       - colour
       - conferenceId
       - id
+      - isHidden
       - name
       - priority
       backend_only: false
@@ -1121,6 +1122,7 @@
       - colour
       - conferenceId
       - id
+      - isHidden
       - name
       - priority
       filter:
@@ -1145,6 +1147,7 @@
       - conferenceId
       - created_at
       - id
+      - isHidden
       - name
       - priority
       - updated_at
@@ -1184,6 +1187,7 @@
     permission:
       columns:
       - colour
+      - isHidden
       - name
       - priority
       filter:

--- a/hasura/migrations/1630536019590_alter_table_collection_Exhibition_add_column_isHidden/down.sql
+++ b/hasura/migrations/1630536019590_alter_table_collection_Exhibition_add_column_isHidden/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "collection"."Exhibition" add column "isHidden" boolean
+--  not null default 'false';

--- a/hasura/migrations/1630536019590_alter_table_collection_Exhibition_add_column_isHidden/up.sql
+++ b/hasura/migrations/1630536019590_alter_table_collection_Exhibition_add_column_isHidden/up.sql
@@ -1,0 +1,2 @@
+alter table "collection"."Exhibition" add column "isHidden" boolean
+ not null default 'false';

--- a/shared/src/import/intermediary.ts
+++ b/shared/src/import/intermediary.ts
@@ -173,6 +173,7 @@ export interface IntermediaryExhibitionDescriptor {
     name?: string;
     colour?: string;
     priority?: number;
+    isHidden?: boolean;
 }
 
 export interface IntermediaryTagDescriptor {


### PR DESCRIPTION
## What's improved

Enables us to hide exhibitions from the main list of exhibitions, so that when they're being used for "session groupings", they don't clutter and hide the actual exhibitions.

## Upgrading

Instructions for other developers on how to upgrade their environment after
pulling this new code. Please tick (i.e. put an 'x' in) the boxes for the
actions that are necessary.

- [x] Run GraphQL Codegen in the [frontend/actions service/playout service/realtime service]
- [ ] Re-install NPM packages in [insert name of folder]
- [x] Apply Hasura migrations
- [x] Apply Hasura metadata
- [ ] Update Auth0 rules
- [ ] Update environment variables
- [ ] Re-deploy AWS CDK [and update AWS environment variables]

## Deployment

Instructions for how to deploy these changes to production. Please tick (i.e.
put an 'x' in) the boxes for the actions that are necessary.

- [x] Apply migrations to Hasura
- [x] Apply metadata to Hasura
- [ ] Reload enum table/values in Hasura for [table names]
- [x] Re-deploy frontend
- [ ] Re-deploy actions service
- [ ] Re-deploy playout service
- [ ] Re-deploy real-time service
- [ ] Flush real-time service state (Redis/RabbitMQ)
- [ ] Update environment variables for [name of component]

Any other steps necessary to re-deploy? No.
