### PR TITLE
🗃 Fix plaintext version of emails

### DIFF
--- a/frontend/src/aspects/Invitation/AcceptInvitationPage.tsx
+++ b/frontend/src/aspects/Invitation/AcceptInvitationPage.tsx
@@ -44,25 +44,6 @@ gql`
             ok
         }
     }
-
-    mutation Invitation_ConfirmWithCode($inviteCode: uuid!, $confirmationCode: String!) {
-        invitationConfirmWithCode(inviteInput: { inviteCode: $inviteCode, confirmationCode: $confirmationCode }) {
-            confSlug
-            ok
-        }
-    }
-
-    mutation SendInitialConfirmationEmail($inviteCode: uuid!) {
-        invitationConfirmSendInitialEmail(inviteInput: { inviteCode: $inviteCode }) {
-            sent
-        }
-    }
-
-    mutation SendRepeatConfirmationEmail($inviteCode: uuid!) {
-        invitationConfirmSendRepeatEmail(inviteInput: { inviteCode: $inviteCode }) {
-            sent
-        }
-    }
 `;
 
 const Spinner = () => (

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -33,11 +33,6 @@ export type Boolean_Comparison_Exp = {
   readonly _nin?: Maybe<ReadonlyArray<Scalars['Boolean']>>;
 };
 
-export type ConfirmInvitationInput = {
-  readonly confirmationCode: Scalars['String'];
-  readonly inviteCode: Scalars['uuid'];
-};
-
 export type ConfirmInvitationOutput = {
   readonly __typename?: 'ConfirmInvitationOutput';
   readonly confSlug?: Maybe<Scalars['String']>;
@@ -706,15 +701,6 @@ export type Int_Comparison_Exp = {
   readonly _lte?: Maybe<Scalars['Int']>;
   readonly _neq?: Maybe<Scalars['Int']>;
   readonly _nin?: Maybe<ReadonlyArray<Scalars['Int']>>;
-};
-
-export type InvitationConfirmationEmailInput = {
-  readonly inviteCode: Scalars['uuid'];
-};
-
-export type InvitationConfirmationEmailOutput = {
-  readonly __typename?: 'InvitationConfirmationEmailOutput';
-  readonly sent: Scalars['Boolean'];
 };
 
 export type JoinEventVonageSessionOutput = {
@@ -14460,9 +14446,6 @@ export type Mutation_Root = {
   /** insert a single row into the table: "video.YouTubeUpload" */
   readonly insert_video_YouTubeUpload_one?: Maybe<Video_YouTubeUpload>;
   readonly invitationConfirmCurrent?: Maybe<ConfirmInvitationOutput>;
-  readonly invitationConfirmSendInitialEmail?: Maybe<InvitationConfirmationEmailOutput>;
-  readonly invitationConfirmSendRepeatEmail?: Maybe<InvitationConfirmationEmailOutput>;
-  readonly invitationConfirmWithCode?: Maybe<ConfirmInvitationOutput>;
   readonly joinEventVonageSession?: Maybe<JoinEventVonageSessionOutput>;
   readonly joinRoomChimeSession?: Maybe<JoinRoomChimeSessionOutput>;
   readonly joinRoomVonageSession?: Maybe<JoinRoomVonageSessionOutput>;
@@ -17115,24 +17098,6 @@ export type Mutation_RootInsert_Video_YouTubeUpload_OneArgs = {
 /** mutation root */
 export type Mutation_RootInvitationConfirmCurrentArgs = {
   inviteCode: Scalars['uuid'];
-};
-
-
-/** mutation root */
-export type Mutation_RootInvitationConfirmSendInitialEmailArgs = {
-  inviteInput: InvitationConfirmationEmailInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootInvitationConfirmSendRepeatEmailArgs = {
-  inviteInput: InvitationConfirmationEmailInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootInvitationConfirmWithCodeArgs = {
-  inviteInput: ConfirmInvitationInput;
 };
 
 
@@ -37109,28 +37074,6 @@ export type Invitation_ConfirmCurrentMutationVariables = Exact<{
 
 export type Invitation_ConfirmCurrentMutation = { readonly __typename?: 'mutation_root', readonly invitationConfirmCurrent?: Maybe<{ readonly __typename?: 'ConfirmInvitationOutput', readonly confSlug?: Maybe<string>, readonly ok: string }> };
 
-export type Invitation_ConfirmWithCodeMutationVariables = Exact<{
-  inviteCode: Scalars['uuid'];
-  confirmationCode: Scalars['String'];
-}>;
-
-
-export type Invitation_ConfirmWithCodeMutation = { readonly __typename?: 'mutation_root', readonly invitationConfirmWithCode?: Maybe<{ readonly __typename?: 'ConfirmInvitationOutput', readonly confSlug?: Maybe<string>, readonly ok: string }> };
-
-export type SendInitialConfirmationEmailMutationVariables = Exact<{
-  inviteCode: Scalars['uuid'];
-}>;
-
-
-export type SendInitialConfirmationEmailMutation = { readonly __typename?: 'mutation_root', readonly invitationConfirmSendInitialEmail?: Maybe<{ readonly __typename?: 'InvitationConfirmationEmailOutput', readonly sent: boolean }> };
-
-export type SendRepeatConfirmationEmailMutationVariables = Exact<{
-  inviteCode: Scalars['uuid'];
-}>;
-
-
-export type SendRepeatConfirmationEmailMutation = { readonly __typename?: 'mutation_root', readonly invitationConfirmSendRepeatEmail?: Maybe<{ readonly __typename?: 'InvitationConfirmationEmailOutput', readonly sent: boolean }> };
-
 export type GetEventsInNextHourQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
   now: Scalars['timestamptz'];
@@ -48799,109 +48742,6 @@ export function useInvitation_ConfirmCurrentMutation(baseOptions?: Apollo.Mutati
 export type Invitation_ConfirmCurrentMutationHookResult = ReturnType<typeof useInvitation_ConfirmCurrentMutation>;
 export type Invitation_ConfirmCurrentMutationResult = Apollo.MutationResult<Invitation_ConfirmCurrentMutation>;
 export type Invitation_ConfirmCurrentMutationOptions = Apollo.BaseMutationOptions<Invitation_ConfirmCurrentMutation, Invitation_ConfirmCurrentMutationVariables>;
-export const Invitation_ConfirmWithCodeDocument = gql`
-    mutation Invitation_ConfirmWithCode($inviteCode: uuid!, $confirmationCode: String!) {
-  invitationConfirmWithCode(
-    inviteInput: {inviteCode: $inviteCode, confirmationCode: $confirmationCode}
-  ) {
-    confSlug
-    ok
-  }
-}
-    `;
-export type Invitation_ConfirmWithCodeMutationFn = Apollo.MutationFunction<Invitation_ConfirmWithCodeMutation, Invitation_ConfirmWithCodeMutationVariables>;
-
-/**
- * __useInvitation_ConfirmWithCodeMutation__
- *
- * To run a mutation, you first call `useInvitation_ConfirmWithCodeMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useInvitation_ConfirmWithCodeMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [invitationConfirmWithCodeMutation, { data, loading, error }] = useInvitation_ConfirmWithCodeMutation({
- *   variables: {
- *      inviteCode: // value for 'inviteCode'
- *      confirmationCode: // value for 'confirmationCode'
- *   },
- * });
- */
-export function useInvitation_ConfirmWithCodeMutation(baseOptions?: Apollo.MutationHookOptions<Invitation_ConfirmWithCodeMutation, Invitation_ConfirmWithCodeMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<Invitation_ConfirmWithCodeMutation, Invitation_ConfirmWithCodeMutationVariables>(Invitation_ConfirmWithCodeDocument, options);
-      }
-export type Invitation_ConfirmWithCodeMutationHookResult = ReturnType<typeof useInvitation_ConfirmWithCodeMutation>;
-export type Invitation_ConfirmWithCodeMutationResult = Apollo.MutationResult<Invitation_ConfirmWithCodeMutation>;
-export type Invitation_ConfirmWithCodeMutationOptions = Apollo.BaseMutationOptions<Invitation_ConfirmWithCodeMutation, Invitation_ConfirmWithCodeMutationVariables>;
-export const SendInitialConfirmationEmailDocument = gql`
-    mutation SendInitialConfirmationEmail($inviteCode: uuid!) {
-  invitationConfirmSendInitialEmail(inviteInput: {inviteCode: $inviteCode}) {
-    sent
-  }
-}
-    `;
-export type SendInitialConfirmationEmailMutationFn = Apollo.MutationFunction<SendInitialConfirmationEmailMutation, SendInitialConfirmationEmailMutationVariables>;
-
-/**
- * __useSendInitialConfirmationEmailMutation__
- *
- * To run a mutation, you first call `useSendInitialConfirmationEmailMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useSendInitialConfirmationEmailMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [sendInitialConfirmationEmailMutation, { data, loading, error }] = useSendInitialConfirmationEmailMutation({
- *   variables: {
- *      inviteCode: // value for 'inviteCode'
- *   },
- * });
- */
-export function useSendInitialConfirmationEmailMutation(baseOptions?: Apollo.MutationHookOptions<SendInitialConfirmationEmailMutation, SendInitialConfirmationEmailMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<SendInitialConfirmationEmailMutation, SendInitialConfirmationEmailMutationVariables>(SendInitialConfirmationEmailDocument, options);
-      }
-export type SendInitialConfirmationEmailMutationHookResult = ReturnType<typeof useSendInitialConfirmationEmailMutation>;
-export type SendInitialConfirmationEmailMutationResult = Apollo.MutationResult<SendInitialConfirmationEmailMutation>;
-export type SendInitialConfirmationEmailMutationOptions = Apollo.BaseMutationOptions<SendInitialConfirmationEmailMutation, SendInitialConfirmationEmailMutationVariables>;
-export const SendRepeatConfirmationEmailDocument = gql`
-    mutation SendRepeatConfirmationEmail($inviteCode: uuid!) {
-  invitationConfirmSendRepeatEmail(inviteInput: {inviteCode: $inviteCode}) {
-    sent
-  }
-}
-    `;
-export type SendRepeatConfirmationEmailMutationFn = Apollo.MutationFunction<SendRepeatConfirmationEmailMutation, SendRepeatConfirmationEmailMutationVariables>;
-
-/**
- * __useSendRepeatConfirmationEmailMutation__
- *
- * To run a mutation, you first call `useSendRepeatConfirmationEmailMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useSendRepeatConfirmationEmailMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [sendRepeatConfirmationEmailMutation, { data, loading, error }] = useSendRepeatConfirmationEmailMutation({
- *   variables: {
- *      inviteCode: // value for 'inviteCode'
- *   },
- * });
- */
-export function useSendRepeatConfirmationEmailMutation(baseOptions?: Apollo.MutationHookOptions<SendRepeatConfirmationEmailMutation, SendRepeatConfirmationEmailMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<SendRepeatConfirmationEmailMutation, SendRepeatConfirmationEmailMutationVariables>(SendRepeatConfirmationEmailDocument, options);
-      }
-export type SendRepeatConfirmationEmailMutationHookResult = ReturnType<typeof useSendRepeatConfirmationEmailMutation>;
-export type SendRepeatConfirmationEmailMutationResult = Apollo.MutationResult<SendRepeatConfirmationEmailMutation>;
-export type SendRepeatConfirmationEmailMutationOptions = Apollo.BaseMutationOptions<SendRepeatConfirmationEmailMutation, SendRepeatConfirmationEmailMutationVariables>;
 export const GetEventsInNextHourDocument = gql`
     query GetEventsInNextHour($conferenceId: uuid!, $now: timestamptz!, $cutoff: timestamptz!) {
   schedule_Event(

--- a/hasura/metadata/actions.graphql
+++ b/hasura/metadata/actions.graphql
@@ -38,24 +38,6 @@ type Mutation {
 }
 
 type Mutation {
-  invitationConfirmSendInitialEmail (
-    inviteInput: InvitationConfirmationEmailInput!
-  ): InvitationConfirmationEmailOutput
-}
-
-type Mutation {
-  invitationConfirmSendRepeatEmail (
-    inviteInput: InvitationConfirmationEmailInput!
-  ): InvitationConfirmationEmailOutput
-}
-
-type Mutation {
-  invitationConfirmWithCode (
-    inviteInput: ConfirmInvitationInput!
-  ): ConfirmInvitationOutput
-}
-
-type Mutation {
   joinEventVonageSession (
     eventId: uuid!
   ): JoinEventVonageSessionOutput

--- a/hasura/metadata/actions.yaml
+++ b/hasura/metadata/actions.yaml
@@ -61,36 +61,6 @@ actions:
       value_from_env: EVENT_SECRET
   permissions:
   - role: user
-- name: invitationConfirmSendInitialEmail
-  definition:
-    kind: synchronous
-    handler: '{{ACTION_BASE_URL}}/invitation/confirm/send/initial'
-    forward_client_headers: true
-    headers:
-    - name: x-hasura-event-secret
-      value_from_env: EVENT_SECRET
-  permissions:
-  - role: user
-- name: invitationConfirmSendRepeatEmail
-  definition:
-    kind: synchronous
-    handler: '{{ACTION_BASE_URL}}/invitation/confirm/send/repeat'
-    forward_client_headers: true
-    headers:
-    - name: x-hasura-event-secret
-      value_from_env: EVENT_SECRET
-  permissions:
-  - role: user
-- name: invitationConfirmWithCode
-  definition:
-    kind: synchronous
-    handler: '{{ACTION_BASE_URL}}/invitation/confirm/code'
-    forward_client_headers: true
-    headers:
-    - name: x-hasura-event-secret
-      value_from_env: EVENT_SECRET
-  permissions:
-  - role: user
 - name: joinEventVonageSession
   definition:
     kind: synchronous

--- a/services/actions/src/generated/graphql.ts
+++ b/services/actions/src/generated/graphql.ts
@@ -31,11 +31,6 @@ export type Boolean_Comparison_Exp = {
   _nin?: Maybe<Array<Scalars['Boolean']>>;
 };
 
-export type ConfirmInvitationInput = {
-  confirmationCode: Scalars['String'];
-  inviteCode: Scalars['uuid'];
-};
-
 export type ConfirmInvitationOutput = {
   __typename?: 'ConfirmInvitationOutput';
   confSlug?: Maybe<Scalars['String']>;
@@ -704,15 +699,6 @@ export type Int_Comparison_Exp = {
   _lte?: Maybe<Scalars['Int']>;
   _neq?: Maybe<Scalars['Int']>;
   _nin?: Maybe<Array<Scalars['Int']>>;
-};
-
-export type InvitationConfirmationEmailInput = {
-  inviteCode: Scalars['uuid'];
-};
-
-export type InvitationConfirmationEmailOutput = {
-  __typename?: 'InvitationConfirmationEmailOutput';
-  sent: Scalars['Boolean'];
 };
 
 export type JoinEventVonageSessionOutput = {
@@ -4449,6 +4435,7 @@ export type Chat_Flag_Variance_Order_By = {
  *
  *
  * columns and relationships of "chat.Message"
+ *
  */
 export type Chat_Message = {
   __typename?: 'chat_Message';
@@ -4488,6 +4475,7 @@ export type Chat_Message = {
  *
  *
  * columns and relationships of "chat.Message"
+ *
  */
 export type Chat_MessageDataArgs = {
   path?: Maybe<Scalars['String']>;
@@ -4499,6 +4487,7 @@ export type Chat_MessageDataArgs = {
  *
  *
  * columns and relationships of "chat.Message"
+ *
  */
 export type Chat_MessageFlagsArgs = {
   distinct_on?: Maybe<Array<Chat_Flag_Select_Column>>;
@@ -4514,6 +4503,7 @@ export type Chat_MessageFlagsArgs = {
  *
  *
  * columns and relationships of "chat.Message"
+ *
  */
 export type Chat_MessageFlags_AggregateArgs = {
   distinct_on?: Maybe<Array<Chat_Flag_Select_Column>>;
@@ -4529,6 +4519,7 @@ export type Chat_MessageFlags_AggregateArgs = {
  *
  *
  * columns and relationships of "chat.Message"
+ *
  */
 export type Chat_MessageReactionsArgs = {
   distinct_on?: Maybe<Array<Chat_Reaction_Select_Column>>;
@@ -4544,6 +4535,7 @@ export type Chat_MessageReactionsArgs = {
  *
  *
  * columns and relationships of "chat.Message"
+ *
  */
 export type Chat_MessageReactions_AggregateArgs = {
   distinct_on?: Maybe<Array<Chat_Reaction_Select_Column>>;
@@ -5086,6 +5078,7 @@ export type Chat_Message_Variance_Order_By = {
  *
  *
  * columns and relationships of "chat.Pin"
+ *
  */
 export type Chat_Pin = {
   __typename?: 'chat_Pin';
@@ -5891,6 +5884,7 @@ export enum Chat_ReadUpToIndex_Update_Column {
  *
  *
  * columns and relationships of "chat.Subscription"
+ *
  */
 export type Chat_Subscription = {
   __typename?: 'chat_Subscription';
@@ -14450,9 +14444,6 @@ export type Mutation_Root = {
   /** insert a single row into the table: "video.YouTubeUpload" */
   insert_video_YouTubeUpload_one?: Maybe<Video_YouTubeUpload>;
   invitationConfirmCurrent?: Maybe<ConfirmInvitationOutput>;
-  invitationConfirmSendInitialEmail?: Maybe<InvitationConfirmationEmailOutput>;
-  invitationConfirmSendRepeatEmail?: Maybe<InvitationConfirmationEmailOutput>;
-  invitationConfirmWithCode?: Maybe<ConfirmInvitationOutput>;
   joinEventVonageSession?: Maybe<JoinEventVonageSessionOutput>;
   joinRoomChimeSession?: Maybe<JoinRoomChimeSessionOutput>;
   joinRoomVonageSession?: Maybe<JoinRoomVonageSessionOutput>;
@@ -17105,24 +17096,6 @@ export type Mutation_RootInsert_Video_YouTubeUpload_OneArgs = {
 /** mutation root */
 export type Mutation_RootInvitationConfirmCurrentArgs = {
   inviteCode: Scalars['uuid'];
-};
-
-
-/** mutation root */
-export type Mutation_RootInvitationConfirmSendInitialEmailArgs = {
-  inviteInput: InvitationConfirmationEmailInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootInvitationConfirmSendRepeatEmailArgs = {
-  inviteInput: InvitationConfirmationEmailInput;
-};
-
-
-/** mutation root */
-export type Mutation_RootInvitationConfirmWithCodeArgs = {
-  inviteInput: ConfirmInvitationInput;
 };
 
 
@@ -27614,6 +27587,7 @@ export type Room_ShuffleRoom_Variance_Order_By = {
  *
  *
  * columns and relationships of "schedule.Continuation"
+ *
  */
 export type Schedule_Continuation = {
   __typename?: 'schedule_Continuation';
@@ -27638,6 +27612,7 @@ export type Schedule_Continuation = {
  *
  *
  * columns and relationships of "schedule.Continuation"
+ *
  */
 export type Schedule_ContinuationToArgs = {
   path?: Maybe<Scalars['String']>;
@@ -32797,6 +32772,7 @@ export enum Video_ChannelStack_Update_Column {
  *
  *
  * columns and relationships of "video.EventParticipantStream"
+ *
  */
 export type Video_EventParticipantStream = {
   __typename?: 'video_EventParticipantStream';
@@ -34968,34 +34944,12 @@ export type FlagInserted_GetSupportAddressQueryVariables = Exact<{
 }>;
 
 
-export type FlagInserted_GetSupportAddressQuery = (
-  { __typename?: 'query_root' }
-  & { chat_Message: Array<(
-    { __typename?: 'chat_Message' }
-    & { chat: (
-      { __typename?: 'chat_Chat' }
-      & { conference: (
-        { __typename?: 'conference_Conference' }
-        & Pick<Conference_Conference, 'id' | 'name' | 'shortName' | 'slug'>
-        & { supportAddress: Array<(
-          { __typename?: 'conference_Configuration' }
-          & Pick<Conference_Configuration, 'conferenceId' | 'key' | 'value'>
-        )> }
-      ) }
-    ) }
-  )> }
-);
+export type FlagInserted_GetSupportAddressQuery = { __typename?: 'query_root', chat_Message: Array<{ __typename?: 'chat_Message', chat: { __typename?: 'chat_Chat', conference: { __typename?: 'conference_Conference', id: any, name: string, shortName: string, slug: string, supportAddress: Array<{ __typename?: 'conference_Configuration', conferenceId: any, key: Conference_ConfigurationKey_Enum, value: any }> } } }> };
 
 export type CombineVideosJob_GetJobsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type CombineVideosJob_GetJobsQuery = (
-  { __typename?: 'query_root' }
-  & { job_queues_CombineVideosJob: Array<(
-    { __typename?: 'job_queues_CombineVideosJob' }
-    & Pick<Job_Queues_CombineVideosJob, 'id' | 'created_at' | 'conferenceId' | 'data' | 'jobStatusName'>
-  )> }
-);
+export type CombineVideosJob_GetJobsQuery = { __typename?: 'query_root', job_queues_CombineVideosJob: Array<{ __typename?: 'job_queues_CombineVideosJob', id: any, created_at: any, conferenceId: any, data: any, jobStatusName: Video_JobStatus_Enum }> };
 
 export type CombineVideosJob_GetElementsQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -35003,13 +34957,7 @@ export type CombineVideosJob_GetElementsQueryVariables = Exact<{
 }>;
 
 
-export type CombineVideosJob_GetElementsQuery = (
-  { __typename?: 'query_root' }
-  & { content_Element: Array<(
-    { __typename?: 'content_Element' }
-    & Pick<Content_Element, 'id' | 'data' | 'itemId'>
-  )> }
-);
+export type CombineVideosJob_GetElementsQuery = { __typename?: 'query_root', content_Element: Array<{ __typename?: 'content_Element', id: any, data: any, itemId: any }> };
 
 export type CombineVideosJob_FailJobMutationVariables = Exact<{
   combineVideosJobId: Scalars['uuid'];
@@ -35017,13 +34965,7 @@ export type CombineVideosJob_FailJobMutationVariables = Exact<{
 }>;
 
 
-export type CombineVideosJob_FailJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_CombineVideosJob?: Maybe<(
-    { __typename?: 'job_queues_CombineVideosJob_mutation_response' }
-    & Pick<Job_Queues_CombineVideosJob_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type CombineVideosJob_FailJobMutation = { __typename?: 'mutation_root', update_job_queues_CombineVideosJob?: Maybe<{ __typename?: 'job_queues_CombineVideosJob_mutation_response', affected_rows: number }> };
 
 export type CombineVideosJob_StartJobMutationVariables = Exact<{
   combineVideosJobId: Scalars['uuid'];
@@ -35031,39 +34973,21 @@ export type CombineVideosJob_StartJobMutationVariables = Exact<{
 }>;
 
 
-export type CombineVideosJob_StartJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_CombineVideosJob?: Maybe<(
-    { __typename?: 'job_queues_CombineVideosJob_mutation_response' }
-    & Pick<Job_Queues_CombineVideosJob_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type CombineVideosJob_StartJobMutation = { __typename?: 'mutation_root', update_job_queues_CombineVideosJob?: Maybe<{ __typename?: 'job_queues_CombineVideosJob_mutation_response', affected_rows: number }> };
 
 export type CombineVideosJob_CompleteJobMutationVariables = Exact<{
   combineVideosJobId: Scalars['uuid'];
 }>;
 
 
-export type CombineVideosJob_CompleteJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_CombineVideosJob?: Maybe<(
-    { __typename?: 'job_queues_CombineVideosJob_mutation_response' }
-    & Pick<Job_Queues_CombineVideosJob_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type CombineVideosJob_CompleteJobMutation = { __typename?: 'mutation_root', update_job_queues_CombineVideosJob?: Maybe<{ __typename?: 'job_queues_CombineVideosJob_mutation_response', affected_rows: number }> };
 
 export type MediaConvert_GetCombineVideosJobQueryVariables = Exact<{
   combineVideosJobId: Scalars['uuid'];
 }>;
 
 
-export type MediaConvert_GetCombineVideosJobQuery = (
-  { __typename?: 'query_root' }
-  & { job_queues_CombineVideosJob_by_pk?: Maybe<(
-    { __typename?: 'job_queues_CombineVideosJob' }
-    & Pick<Job_Queues_CombineVideosJob, 'id' | 'conferenceId' | 'outputName'>
-  )> }
-);
+export type MediaConvert_GetCombineVideosJobQuery = { __typename?: 'query_root', job_queues_CombineVideosJob_by_pk?: Maybe<{ __typename?: 'job_queues_CombineVideosJob', id: any, conferenceId: any, outputName: string }> };
 
 export type CombineVideosJob_CreateElementMutationVariables = Exact<{
   data: Scalars['jsonb'];
@@ -35073,13 +34997,7 @@ export type CombineVideosJob_CreateElementMutationVariables = Exact<{
 }>;
 
 
-export type CombineVideosJob_CreateElementMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_content_Element_one?: Maybe<(
-    { __typename?: 'content_Element' }
-    & Pick<Content_Element, 'id'>
-  )> }
-);
+export type CombineVideosJob_CreateElementMutation = { __typename?: 'mutation_root', insert_content_Element_one?: Maybe<{ __typename?: 'content_Element', id: any }> };
 
 export type CheckForFrontendHostsQueryVariables = Exact<{
   host: Scalars['jsonb'];
@@ -35094,78 +35012,35 @@ export type ElementAddNewVersionMutationVariables = Exact<{
 }>;
 
 
-export type ElementAddNewVersionMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_content_Element_by_pk?: Maybe<(
-    { __typename?: 'content_Element' }
-    & Pick<Content_Element, 'id'>
-  )> }
-);
+export type ElementAddNewVersionMutation = { __typename?: 'mutation_root', update_content_Element_by_pk?: Maybe<{ __typename?: 'content_Element', id: any }> };
 
 export type GetElementDetailsQueryVariables = Exact<{
   elementId: Scalars['uuid'];
 }>;
 
 
-export type GetElementDetailsQuery = (
-  { __typename?: 'query_root' }
-  & { content_Element_by_pk?: Maybe<(
-    { __typename?: 'content_Element' }
-    & Pick<Content_Element, 'id' | 'name'>
-    & { conference: (
-      { __typename?: 'conference_Conference' }
-      & Pick<Conference_Conference, 'id' | 'name' | 'shortName'>
-    ), item: (
-      { __typename?: 'content_Item' }
-      & Pick<Content_Item, 'id' | 'title'>
-    ) }
-  )> }
-);
+export type GetElementDetailsQuery = { __typename?: 'query_root', content_Element_by_pk?: Maybe<{ __typename?: 'content_Element', id: any, name: string, conference: { __typename?: 'conference_Conference', id: any, name: string, shortName: string }, item: { __typename?: 'content_Item', id: any, title: string } }> };
 
 export type GetUploadersForElementQueryVariables = Exact<{
   elementId: Scalars['uuid'];
 }>;
 
 
-export type GetUploadersForElementQuery = (
-  { __typename?: 'query_root' }
-  & { content_Uploader: Array<(
-    { __typename?: 'content_Uploader' }
-    & Pick<Content_Uploader, 'name' | 'id' | 'email'>
-  )> }
-);
+export type GetUploadersForElementQuery = { __typename?: 'query_root', content_Uploader: Array<{ __typename?: 'content_Uploader', name: string, id: any, email: string }> };
 
 export type GetUploadableElementQueryVariables = Exact<{
   elementId: Scalars['uuid'];
 }>;
 
 
-export type GetUploadableElementQuery = (
-  { __typename?: 'query_root' }
-  & { content_Element_by_pk?: Maybe<(
-    { __typename?: 'content_Element' }
-    & Pick<Content_Element, 'accessToken' | 'id'>
-  )> }
-);
+export type GetUploadableElementQuery = { __typename?: 'query_root', content_Element_by_pk?: Maybe<{ __typename?: 'content_Element', accessToken: string, id: any }> };
 
 export type GetUploadAgreementQueryVariables = Exact<{
   accessToken: Scalars['String'];
 }>;
 
 
-export type GetUploadAgreementQuery = (
-  { __typename?: 'query_root' }
-  & { content_Element: Array<(
-    { __typename?: 'content_Element' }
-    & { conference: (
-      { __typename?: 'conference_Conference' }
-      & { configurations: Array<(
-        { __typename?: 'conference_Configuration' }
-        & Pick<Conference_Configuration, 'conferenceId' | 'key' | 'value'>
-      )> }
-    ) }
-  )> }
-);
+export type GetUploadAgreementQuery = { __typename?: 'query_root', content_Element: Array<{ __typename?: 'content_Element', conference: { __typename?: 'conference_Conference', configurations: Array<{ __typename?: 'conference_Configuration', conferenceId: any, key: Conference_ConfigurationKey_Enum, value: any }> } }> };
 
 export type CustomEmail_SelectRegistrantsQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -35173,51 +35048,19 @@ export type CustomEmail_SelectRegistrantsQueryVariables = Exact<{
 }>;
 
 
-export type CustomEmail_SelectRegistrantsQuery = (
-  { __typename?: 'query_root' }
-  & { registrant_Registrant: Array<(
-    { __typename?: 'registrant_Registrant' }
-    & Pick<Registrant_Registrant, 'id'>
-    & { invitation?: Maybe<(
-      { __typename?: 'registrant_Invitation' }
-      & Pick<Registrant_Invitation, 'invitedEmailAddress' | 'id'>
-    )>, user?: Maybe<(
-      { __typename?: 'User' }
-      & Pick<User, 'id' | 'email'>
-    )> }
-  )> }
-);
+export type CustomEmail_SelectRegistrantsQuery = { __typename?: 'query_root', registrant_Registrant: Array<{ __typename?: 'registrant_Registrant', id: any, invitation?: Maybe<{ __typename?: 'registrant_Invitation', invitedEmailAddress: string, id: any }>, user?: Maybe<{ __typename?: 'User', id: string, email?: Maybe<string> }> }> };
 
 export type MarkAndSelectUnprocessedCustomEmailJobsMutationVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MarkAndSelectUnprocessedCustomEmailJobsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_CustomEmailJob?: Maybe<(
-    { __typename?: 'job_queues_CustomEmailJob_mutation_response' }
-    & { returning: Array<(
-      { __typename?: 'job_queues_CustomEmailJob' }
-      & Pick<Job_Queues_CustomEmailJob, 'id' | 'registrantIds' | 'conferenceId' | 'subject' | 'htmlBody'>
-    )> }
-  )> }
-);
+export type MarkAndSelectUnprocessedCustomEmailJobsMutation = { __typename?: 'mutation_root', update_job_queues_CustomEmailJob?: Maybe<{ __typename?: 'job_queues_CustomEmailJob_mutation_response', returning: Array<{ __typename?: 'job_queues_CustomEmailJob', id: any, registrantIds: any, conferenceId: any, subject: string, htmlBody: string }> }> };
 
 export type UnmarkCustomEmailJobsMutationVariables = Exact<{
   ids: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type UnmarkCustomEmailJobsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_CustomEmailJob?: Maybe<(
-    { __typename?: 'job_queues_CustomEmailJob_mutation_response' }
-    & Pick<Job_Queues_CustomEmailJob_Mutation_Response, 'affected_rows'>
-    & { returning: Array<(
-      { __typename?: 'job_queues_CustomEmailJob' }
-      & Pick<Job_Queues_CustomEmailJob, 'id'>
-    )> }
-  )> }
-);
+export type UnmarkCustomEmailJobsMutation = { __typename?: 'mutation_root', update_job_queues_CustomEmailJob?: Maybe<{ __typename?: 'job_queues_CustomEmailJob_mutation_response', affected_rows: number, returning: Array<{ __typename?: 'job_queues_CustomEmailJob', id: any }> }> };
 
 export type ConferenceEmailConfigurationQueryVariables = Exact<{
   conferenceId?: Maybe<Scalars['uuid']>;
@@ -35225,55 +35068,19 @@ export type ConferenceEmailConfigurationQueryVariables = Exact<{
 }>;
 
 
-export type ConferenceEmailConfigurationQuery = (
-  { __typename?: 'query_root' }
-  & { support: Maybe<Array<(
-    { __typename?: 'conference_Configuration' }
-    & Pick<Conference_Configuration, 'key' | 'value'>
-  )>>, techSupport: Maybe<Array<(
-    { __typename?: 'conference_Configuration' }
-    & Pick<Conference_Configuration, 'key' | 'value'>
-  )>>, hostOrganisationName?: Maybe<(
-    { __typename?: 'system_Configuration' }
-    & Pick<System_Configuration, 'key' | 'value'>
-  )>, stopEmails?: Maybe<(
-    { __typename?: 'system_Configuration' }
-    & Pick<System_Configuration, 'key' | 'value'>
-  )>, frontendHost: Maybe<Array<(
-    { __typename?: 'conference_Configuration' }
-    & Pick<Conference_Configuration, 'key' | 'value'>
-  )>>, defaultFrontendHost?: Maybe<(
-    { __typename?: 'system_Configuration' }
-    & Pick<System_Configuration, 'key' | 'value'>
-  )>, allowEmailsToDomains?: Maybe<(
-    { __typename?: 'system_Configuration' }
-    & Pick<System_Configuration, 'key' | 'value'>
-  )> }
-);
+export type ConferenceEmailConfigurationQuery = { __typename?: 'query_root', support: Maybe<Array<{ __typename?: 'conference_Configuration', key: Conference_ConfigurationKey_Enum, value: any }>>, techSupport: Maybe<Array<{ __typename?: 'conference_Configuration', key: Conference_ConfigurationKey_Enum, value: any }>>, hostOrganisationName?: Maybe<{ __typename?: 'system_Configuration', key: System_ConfigurationKey_Enum, value: any }>, stopEmails?: Maybe<{ __typename?: 'system_Configuration', key: System_ConfigurationKey_Enum, value: any }>, frontendHost: Maybe<Array<{ __typename?: 'conference_Configuration', key: Conference_ConfigurationKey_Enum, value: any }>>, defaultFrontendHost?: Maybe<{ __typename?: 'system_Configuration', key: System_ConfigurationKey_Enum, value: any }>, allowEmailsToDomains?: Maybe<{ __typename?: 'system_Configuration', key: System_ConfigurationKey_Enum, value: any }> };
 
 export type InsertEmailsMutationVariables = Exact<{
   objects: Array<Email_Insert_Input> | Email_Insert_Input;
 }>;
 
 
-export type InsertEmailsMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_Email?: Maybe<(
-    { __typename?: 'Email_mutation_response' }
-    & Pick<Email_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type InsertEmailsMutation = { __typename?: 'mutation_root', insert_Email?: Maybe<{ __typename?: 'Email_mutation_response', affected_rows: number }> };
 
 export type SelectUnsentEmailIdsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SelectUnsentEmailIdsQuery = (
-  { __typename?: 'query_root' }
-  & { Email: Array<(
-    { __typename?: 'Email' }
-    & Pick<Email, 'id'>
-  )> }
-);
+export type SelectUnsentEmailIdsQuery = { __typename?: 'query_root', Email: Array<{ __typename?: 'Email', id: any }> };
 
 export type MarkAndSelectUnsentEmailsMutationVariables = Exact<{
   ids: Array<Scalars['uuid']> | Scalars['uuid'];
@@ -35281,66 +35088,26 @@ export type MarkAndSelectUnsentEmailsMutationVariables = Exact<{
 }>;
 
 
-export type MarkAndSelectUnsentEmailsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_Email?: Maybe<(
-    { __typename?: 'Email_mutation_response' }
-    & { returning: Array<(
-      { __typename?: 'Email' }
-      & Pick<Email, 'emailAddress' | 'htmlContents' | 'plainTextContents' | 'id' | 'subject' | 'retriesCount'>
-    )> }
-  )> }
-);
+export type MarkAndSelectUnsentEmailsMutation = { __typename?: 'mutation_root', update_Email?: Maybe<{ __typename?: 'Email_mutation_response', returning: Array<{ __typename?: 'Email', emailAddress: string, htmlContents: string, plainTextContents: string, id: any, subject: string, retriesCount: number }> }> };
 
 export type UnmarkUnsentEmailsMutationVariables = Exact<{
   ids: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type UnmarkUnsentEmailsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_Email?: Maybe<(
-    { __typename?: 'Email_mutation_response' }
-    & Pick<Email_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type UnmarkUnsentEmailsMutation = { __typename?: 'mutation_root', update_Email?: Maybe<{ __typename?: 'Email_mutation_response', affected_rows: number }> };
 
 export type GetSendGridConfigQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetSendGridConfigQuery = (
-  { __typename?: 'query_root' }
-  & { apiKey?: Maybe<(
-    { __typename?: 'system_Configuration' }
-    & Pick<System_Configuration, 'value'>
-  )>, sender?: Maybe<(
-    { __typename?: 'system_Configuration' }
-    & Pick<System_Configuration, 'value'>
-  )>, replyTo?: Maybe<(
-    { __typename?: 'system_Configuration' }
-    & Pick<System_Configuration, 'value'>
-  )> }
-);
+export type GetSendGridConfigQuery = { __typename?: 'query_root', apiKey?: Maybe<{ __typename?: 'system_Configuration', value: any }>, sender?: Maybe<{ __typename?: 'system_Configuration', value: any }>, replyTo?: Maybe<{ __typename?: 'system_Configuration', value: any }> };
 
 export type GetEventChatInfoQueryVariables = Exact<{
   eventId: Scalars['uuid'];
 }>;
 
 
-export type GetEventChatInfoQuery = (
-  { __typename?: 'query_root' }
-  & { schedule_Event_by_pk?: Maybe<(
-    { __typename?: 'schedule_Event' }
-    & Pick<Schedule_Event, 'id' | 'startTime' | 'durationSeconds'>
-    & { room: (
-      { __typename?: 'room_Room' }
-      & Pick<Room_Room, 'id' | 'name' | 'chatId'>
-    ), item?: Maybe<(
-      { __typename?: 'content_Item' }
-      & Pick<Content_Item, 'id' | 'title' | 'chatId'>
-    )> }
-  )> }
-);
+export type GetEventChatInfoQuery = { __typename?: 'query_root', schedule_Event_by_pk?: Maybe<{ __typename?: 'schedule_Event', id: any, startTime: any, durationSeconds: number, room: { __typename?: 'room_Room', id: any, name: string, chatId?: Maybe<any> }, item?: Maybe<{ __typename?: 'content_Item', id: any, title: string, chatId?: Maybe<any> }> }> };
 
 export type StartChatDuplicationMutationVariables = Exact<{
   chatId1: Scalars['uuid'];
@@ -35348,16 +35115,7 @@ export type StartChatDuplicationMutationVariables = Exact<{
 }>;
 
 
-export type StartChatDuplicationMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_chat1?: Maybe<(
-    { __typename?: 'chat_Chat' }
-    & Pick<Chat_Chat, 'id'>
-  )>, update_chat2?: Maybe<(
-    { __typename?: 'chat_Chat' }
-    & Pick<Chat_Chat, 'id'>
-  )> }
-);
+export type StartChatDuplicationMutation = { __typename?: 'mutation_root', update_chat1?: Maybe<{ __typename?: 'chat_Chat', id: any }>, update_chat2?: Maybe<{ __typename?: 'chat_Chat', id: any }> };
 
 export type EndChatDuplicationMutationVariables = Exact<{
   chatId1: Scalars['uuid'];
@@ -35365,69 +35123,28 @@ export type EndChatDuplicationMutationVariables = Exact<{
 }>;
 
 
-export type EndChatDuplicationMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_chat1?: Maybe<(
-    { __typename?: 'chat_Chat' }
-    & Pick<Chat_Chat, 'id'>
-  )>, update_chat2?: Maybe<(
-    { __typename?: 'chat_Chat' }
-    & Pick<Chat_Chat, 'id'>
-  )> }
-);
+export type EndChatDuplicationMutation = { __typename?: 'mutation_root', update_chat1?: Maybe<{ __typename?: 'chat_Chat', id: any }>, update_chat2?: Maybe<{ __typename?: 'chat_Chat', id: any }> };
 
 export type NotifyRealtimeEventEndedMutationVariables = Exact<{
   eventId: Scalars['uuid'];
 }>;
 
 
-export type NotifyRealtimeEventEndedMutation = (
-  { __typename?: 'mutation_root' }
-  & { notifyEventEnded: (
-    { __typename?: 'NotifyEventEnded' }
-    & Pick<NotifyEventEnded, 'ok'>
-  ) }
-);
+export type NotifyRealtimeEventEndedMutation = { __typename?: 'mutation_root', notifyEventEnded: { __typename?: 'NotifyEventEnded', ok: boolean } };
 
 export type GetEventTimingsQueryVariables = Exact<{
   eventId: Scalars['uuid'];
 }>;
 
 
-export type GetEventTimingsQuery = (
-  { __typename?: 'query_root' }
-  & { schedule_Event_by_pk?: Maybe<(
-    { __typename?: 'schedule_Event' }
-    & Pick<Schedule_Event, 'id' | 'name' | 'timingsUpdatedAt' | 'startTime' | 'endTime' | 'conferenceId' | 'intendedRoomModeName'>
-    & { eventVonageSession?: Maybe<(
-      { __typename?: 'video_EventVonageSession' }
-      & Pick<Video_EventVonageSession, 'id' | 'sessionId'>
-    )>, item?: Maybe<(
-      { __typename?: 'content_Item' }
-      & Pick<Content_Item, 'id' | 'title' | 'chatId'>
-    )>, continuations: Array<(
-      { __typename?: 'schedule_Continuation' }
-      & Pick<Schedule_Continuation, 'id' | 'to'>
-    )> }
-  )> }
-);
+export type GetEventTimingsQuery = { __typename?: 'query_root', schedule_Event_by_pk?: Maybe<{ __typename?: 'schedule_Event', id: any, name: string, timingsUpdatedAt: any, startTime: any, endTime?: Maybe<any>, conferenceId: any, intendedRoomModeName: Room_Mode_Enum, eventVonageSession?: Maybe<{ __typename?: 'video_EventVonageSession', id: any, sessionId: string }>, item?: Maybe<{ __typename?: 'content_Item', id: any, title: string, chatId?: Maybe<any> }>, continuations: Array<{ __typename?: 'schedule_Continuation', id: any, to: any }> }> };
 
 export type Event_GetEventVonageSessionQueryVariables = Exact<{
   eventId: Scalars['uuid'];
 }>;
 
 
-export type Event_GetEventVonageSessionQuery = (
-  { __typename?: 'query_root' }
-  & { schedule_Event_by_pk?: Maybe<(
-    { __typename?: 'schedule_Event' }
-    & Pick<Schedule_Event, 'id'>
-    & { eventVonageSession?: Maybe<(
-      { __typename?: 'video_EventVonageSession' }
-      & Pick<Video_EventVonageSession, 'id' | 'sessionId'>
-    )> }
-  )> }
-);
+export type Event_GetEventVonageSessionQuery = { __typename?: 'query_root', schedule_Event_by_pk?: Maybe<{ __typename?: 'schedule_Event', id: any, eventVonageSession?: Maybe<{ __typename?: 'video_EventVonageSession', id: any, sessionId: string }> }> };
 
 export type FindEventConnectionsForParticipantQueryVariables = Exact<{
   personId: Scalars['uuid'];
@@ -35435,23 +35152,7 @@ export type FindEventConnectionsForParticipantQueryVariables = Exact<{
 }>;
 
 
-export type FindEventConnectionsForParticipantQuery = (
-  { __typename?: 'query_root' }
-  & { video_EventParticipantStream_aggregate: (
-    { __typename?: 'video_EventParticipantStream_aggregate' }
-    & { nodes: Array<(
-      { __typename?: 'video_EventParticipantStream' }
-      & Pick<Video_EventParticipantStream, 'vonageConnectionId' | 'id'>
-      & { event: (
-        { __typename?: 'schedule_Event' }
-        & { eventVonageSession?: Maybe<(
-          { __typename?: 'video_EventVonageSession' }
-          & Pick<Video_EventVonageSession, 'id' | 'sessionId'>
-        )> }
-      ) }
-    )> }
-  ) }
-);
+export type FindEventConnectionsForParticipantQuery = { __typename?: 'query_root', video_EventParticipantStream_aggregate: { __typename?: 'video_EventParticipantStream_aggregate', nodes: Array<{ __typename?: 'video_EventParticipantStream', vonageConnectionId: string, id: any, event: { __typename?: 'schedule_Event', eventVonageSession?: Maybe<{ __typename?: 'video_EventVonageSession', id: any, sessionId: string }> } }> } };
 
 export type EventVonageSession_RemoveInvalidStreamsMutationVariables = Exact<{
   validStreamIds: Array<Scalars['String']> | Scalars['String'];
@@ -35459,35 +35160,14 @@ export type EventVonageSession_RemoveInvalidStreamsMutationVariables = Exact<{
 }>;
 
 
-export type EventVonageSession_RemoveInvalidStreamsMutation = (
-  { __typename?: 'mutation_root' }
-  & { delete_video_EventParticipantStream?: Maybe<(
-    { __typename?: 'video_EventParticipantStream_mutation_response' }
-    & Pick<Video_EventParticipantStream_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type EventVonageSession_RemoveInvalidStreamsMutation = { __typename?: 'mutation_root', delete_video_EventParticipantStream?: Maybe<{ __typename?: 'video_EventParticipantStream_mutation_response', affected_rows: number }> };
 
 export type GoogleOAuth_ConferenceConfig_FrontendHostQueryVariables = Exact<{
   registrantId: Scalars['uuid'];
 }>;
 
 
-export type GoogleOAuth_ConferenceConfig_FrontendHostQuery = (
-  { __typename?: 'query_root' }
-  & { registrant?: Maybe<(
-    { __typename?: 'registrant_Registrant' }
-    & { conference: (
-      { __typename?: 'conference_Conference' }
-      & { frontendHost: Array<(
-        { __typename?: 'conference_Configuration' }
-        & Pick<Conference_Configuration, 'value'>
-      )> }
-    ) }
-  )>, defaultFrontendHost?: Maybe<(
-    { __typename?: 'system_Configuration' }
-    & Pick<System_Configuration, 'key' | 'value'>
-  )> }
-);
+export type GoogleOAuth_ConferenceConfig_FrontendHostQuery = { __typename?: 'query_root', registrant?: Maybe<{ __typename?: 'registrant_Registrant', conference: { __typename?: 'conference_Conference', frontendHost: Array<{ __typename?: 'conference_Configuration', value: any }> } }>, defaultFrontendHost?: Maybe<{ __typename?: 'system_Configuration', key: System_ConfigurationKey_Enum, value: any }> };
 
 export type Google_CreateRegistrantGoogleAccountMutationVariables = Exact<{
   registrantId: Scalars['uuid'];
@@ -35497,13 +35177,7 @@ export type Google_CreateRegistrantGoogleAccountMutationVariables = Exact<{
 }>;
 
 
-export type Google_CreateRegistrantGoogleAccountMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_registrant_GoogleAccount_one?: Maybe<(
-    { __typename?: 'registrant_GoogleAccount' }
-    & Pick<Registrant_GoogleAccount, 'id'>
-  )> }
-);
+export type Google_CreateRegistrantGoogleAccountMutation = { __typename?: 'mutation_root', insert_registrant_GoogleAccount_one?: Maybe<{ __typename?: 'registrant_GoogleAccount', id: any }> };
 
 export type CreateYouTubeUploadMutationVariables = Exact<{
   elementId: Scalars['uuid'];
@@ -35516,73 +35190,28 @@ export type CreateYouTubeUploadMutationVariables = Exact<{
 }>;
 
 
-export type CreateYouTubeUploadMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_video_YouTubeUpload_one?: Maybe<(
-    { __typename?: 'video_YouTubeUpload' }
-    & Pick<Video_YouTubeUpload, 'id'>
-  )> }
-);
+export type CreateYouTubeUploadMutation = { __typename?: 'mutation_root', insert_video_YouTubeUpload_one?: Maybe<{ __typename?: 'video_YouTubeUpload', id: any }> };
 
 export type SelectNewUploadYouTubeVideoJobsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SelectNewUploadYouTubeVideoJobsQuery = (
-  { __typename?: 'query_root' }
-  & { job_queues_UploadYouTubeVideoJob: Array<(
-    { __typename?: 'job_queues_UploadYouTubeVideoJob' }
-    & Pick<Job_Queues_UploadYouTubeVideoJob, 'id'>
-  )> }
-);
+export type SelectNewUploadYouTubeVideoJobsQuery = { __typename?: 'query_root', job_queues_UploadYouTubeVideoJob: Array<{ __typename?: 'job_queues_UploadYouTubeVideoJob', id: any }> };
 
 export type MarkAndSelectNewUploadYouTubeVideoJobsMutationVariables = Exact<{
   ids: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type MarkAndSelectNewUploadYouTubeVideoJobsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_UploadYouTubeVideoJob?: Maybe<(
-    { __typename?: 'job_queues_UploadYouTubeVideoJob_mutation_response' }
-    & { returning: Array<(
-      { __typename?: 'job_queues_UploadYouTubeVideoJob' }
-      & UploadYouTubeVideoJobDataFragment
-    )> }
-  )> }
-);
+export type MarkAndSelectNewUploadYouTubeVideoJobsMutation = { __typename?: 'mutation_root', update_job_queues_UploadYouTubeVideoJob?: Maybe<{ __typename?: 'job_queues_UploadYouTubeVideoJob_mutation_response', returning: Array<{ __typename?: 'job_queues_UploadYouTubeVideoJob', id: any, conferenceId: any, jobStatusName: Video_JobStatus_Enum, retriesCount: number, videoTitle: string, videoDescription: string, videoPrivacyStatus: string, playlistId?: Maybe<string>, registrantGoogleAccount: { __typename?: 'registrant_GoogleAccount', id: any, tokenData: any, googleAccountEmail: string }, element: { __typename?: 'content_Element', data: any, id: any, item: { __typename?: 'content_Item', id: any, title: string } } }> }> };
 
-export type UploadYouTubeVideoJobDataFragment = (
-  { __typename?: 'job_queues_UploadYouTubeVideoJob' }
-  & Pick<Job_Queues_UploadYouTubeVideoJob, 'id' | 'conferenceId' | 'jobStatusName' | 'retriesCount' | 'videoTitle' | 'videoDescription' | 'videoPrivacyStatus' | 'playlistId'>
-  & { registrantGoogleAccount: (
-    { __typename?: 'registrant_GoogleAccount' }
-    & Pick<Registrant_GoogleAccount, 'id' | 'tokenData' | 'googleAccountEmail'>
-  ), element: (
-    { __typename?: 'content_Element' }
-    & Pick<Content_Element, 'data' | 'id'>
-    & { item: (
-      { __typename?: 'content_Item' }
-      & Pick<Content_Item, 'id' | 'title'>
-    ) }
-  ) }
-);
+export type UploadYouTubeVideoJobDataFragment = { __typename?: 'job_queues_UploadYouTubeVideoJob', id: any, conferenceId: any, jobStatusName: Video_JobStatus_Enum, retriesCount: number, videoTitle: string, videoDescription: string, videoPrivacyStatus: string, playlistId?: Maybe<string>, registrantGoogleAccount: { __typename?: 'registrant_GoogleAccount', id: any, tokenData: any, googleAccountEmail: string }, element: { __typename?: 'content_Element', data: any, id: any, item: { __typename?: 'content_Item', id: any, title: string } } };
 
 export type UnmarkUploadYouTubeVideoJobsMutationVariables = Exact<{
   ids: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type UnmarkUploadYouTubeVideoJobsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_UploadYouTubeVideoJob?: Maybe<(
-    { __typename?: 'job_queues_UploadYouTubeVideoJob_mutation_response' }
-    & Pick<Job_Queues_UploadYouTubeVideoJob_Mutation_Response, 'affected_rows'>
-    & { returning: Array<(
-      { __typename?: 'job_queues_UploadYouTubeVideoJob' }
-      & Pick<Job_Queues_UploadYouTubeVideoJob, 'id'>
-    )> }
-  )> }
-);
+export type UnmarkUploadYouTubeVideoJobsMutation = { __typename?: 'mutation_root', update_job_queues_UploadYouTubeVideoJob?: Maybe<{ __typename?: 'job_queues_UploadYouTubeVideoJob_mutation_response', affected_rows: number, returning: Array<{ __typename?: 'job_queues_UploadYouTubeVideoJob', id: any }> }> };
 
 export type FailUploadYouTubeVideoJobMutationVariables = Exact<{
   id: Scalars['uuid'];
@@ -35590,47 +35219,18 @@ export type FailUploadYouTubeVideoJobMutationVariables = Exact<{
 }>;
 
 
-export type FailUploadYouTubeVideoJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_UploadYouTubeVideoJob_by_pk?: Maybe<(
-    { __typename?: 'job_queues_UploadYouTubeVideoJob' }
-    & Pick<Job_Queues_UploadYouTubeVideoJob, 'id'>
-  )> }
-);
+export type FailUploadYouTubeVideoJobMutation = { __typename?: 'mutation_root', update_job_queues_UploadYouTubeVideoJob_by_pk?: Maybe<{ __typename?: 'job_queues_UploadYouTubeVideoJob', id: any }> };
 
 export type CompleteUploadYouTubeVideoJobMutationVariables = Exact<{
   id: Scalars['uuid'];
 }>;
 
 
-export type CompleteUploadYouTubeVideoJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_UploadYouTubeVideoJob_by_pk?: Maybe<(
-    { __typename?: 'job_queues_UploadYouTubeVideoJob' }
-    & Pick<Job_Queues_UploadYouTubeVideoJob, 'id'>
-  )> }
-);
+export type CompleteUploadYouTubeVideoJobMutation = { __typename?: 'mutation_root', update_job_queues_UploadYouTubeVideoJob_by_pk?: Maybe<{ __typename?: 'job_queues_UploadYouTubeVideoJob', id: any }> };
 
-export type InvitationPartsFragment = (
-  { __typename?: 'registrant_Invitation' }
-  & Pick<Registrant_Invitation, 'registrantId' | 'confirmationCode' | 'id' | 'inviteCode' | 'invitedEmailAddress' | 'linkToUserId' | 'updatedAt' | 'createdAt'>
-  & { registrant: (
-    { __typename?: 'registrant_Registrant' }
-    & Pick<Registrant_Registrant, 'displayName' | 'userId'>
-    & { conference: (
-      { __typename?: 'conference_Conference' }
-      & Pick<Conference_Conference, 'name' | 'slug'>
-    ) }
-  ), user?: Maybe<(
-    { __typename?: 'User' }
-    & Pick<User, 'email'>
-  )> }
-);
+export type InvitationPartsFragment = { __typename?: 'registrant_Invitation', registrantId: any, confirmationCode?: Maybe<any>, id: any, inviteCode: any, invitedEmailAddress: string, linkToUserId?: Maybe<string>, updatedAt: any, createdAt: any, registrant: { __typename?: 'registrant_Registrant', displayName: string, userId?: Maybe<string>, conference: { __typename?: 'conference_Conference', name: string, slug: string } }, user?: Maybe<{ __typename?: 'User', email?: Maybe<string> }> };
 
-export type InvitedUserPartsFragment = (
-  { __typename?: 'User' }
-  & Pick<User, 'id' | 'email'>
-);
+export type InvitedUserPartsFragment = { __typename?: 'User', id: string, email?: Maybe<string> };
 
 export type SelectInvitationAndUserQueryVariables = Exact<{
   inviteCode: Scalars['uuid'];
@@ -35638,16 +35238,7 @@ export type SelectInvitationAndUserQueryVariables = Exact<{
 }>;
 
 
-export type SelectInvitationAndUserQuery = (
-  { __typename?: 'query_root' }
-  & { registrant_Invitation: Array<(
-    { __typename?: 'registrant_Invitation' }
-    & InvitationPartsFragment
-  )>, User_by_pk?: Maybe<(
-    { __typename?: 'User' }
-    & InvitedUserPartsFragment
-  )> }
-);
+export type SelectInvitationAndUserQuery = { __typename?: 'query_root', registrant_Invitation: Array<{ __typename?: 'registrant_Invitation', registrantId: any, confirmationCode?: Maybe<any>, id: any, inviteCode: any, invitedEmailAddress: string, linkToUserId?: Maybe<string>, updatedAt: any, createdAt: any, registrant: { __typename?: 'registrant_Registrant', displayName: string, userId?: Maybe<string>, conference: { __typename?: 'conference_Conference', name: string, slug: string } }, user?: Maybe<{ __typename?: 'User', email?: Maybe<string> }> }>, User_by_pk?: Maybe<{ __typename?: 'User', id: string, email?: Maybe<string> }> };
 
 export type UpdateInvitationMutationVariables = Exact<{
   confirmationCode: Scalars['uuid'];
@@ -35657,13 +35248,7 @@ export type UpdateInvitationMutationVariables = Exact<{
 }>;
 
 
-export type UpdateInvitationMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_registrant_Invitation?: Maybe<(
-    { __typename?: 'registrant_Invitation_mutation_response' }
-    & Pick<Registrant_Invitation_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type UpdateInvitationMutation = { __typename?: 'mutation_root', update_registrant_Invitation?: Maybe<{ __typename?: 'registrant_Invitation_mutation_response', affected_rows: number }> };
 
 export type SendFreshInviteConfirmationEmailMutationVariables = Exact<{
   emailAddress: Scalars['String'];
@@ -35675,13 +35260,7 @@ export type SendFreshInviteConfirmationEmailMutationVariables = Exact<{
 }>;
 
 
-export type SendFreshInviteConfirmationEmailMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_Email_one?: Maybe<(
-    { __typename?: 'Email' }
-    & Pick<Email, 'id'>
-  )> }
-);
+export type SendFreshInviteConfirmationEmailMutation = { __typename?: 'mutation_root', insert_Email_one?: Maybe<{ __typename?: 'Email', id: any }> };
 
 export type SetRegistrantUserIdMutationVariables = Exact<{
   registrantId: Scalars['uuid'];
@@ -35689,69 +35268,28 @@ export type SetRegistrantUserIdMutationVariables = Exact<{
 }>;
 
 
-export type SetRegistrantUserIdMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_registrant_Registrant?: Maybe<(
-    { __typename?: 'registrant_Registrant_mutation_response' }
-    & Pick<Registrant_Registrant_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type SetRegistrantUserIdMutation = { __typename?: 'mutation_root', update_registrant_Registrant?: Maybe<{ __typename?: 'registrant_Registrant_mutation_response', affected_rows: number }> };
 
-export type RegistrantWithInvitePartsFragment = (
-  { __typename?: 'registrant_Registrant' }
-  & Pick<Registrant_Registrant, 'id' | 'displayName' | 'userId'>
-  & { conference: (
-    { __typename?: 'conference_Conference' }
-    & Pick<Conference_Conference, 'id' | 'name' | 'shortName' | 'slug'>
-  ), invitation?: Maybe<(
-    { __typename?: 'registrant_Invitation' }
-    & Pick<Registrant_Invitation, 'id' | 'inviteCode' | 'invitedEmailAddress'>
-    & { emails: Array<(
-      { __typename?: 'Email' }
-      & Pick<Email, 'reason'>
-    )> }
-  )> }
-);
+export type RegistrantWithInvitePartsFragment = { __typename?: 'registrant_Registrant', id: any, displayName: string, userId?: Maybe<string>, conference: { __typename?: 'conference_Conference', id: any, name: string, shortName: string, slug: string }, invitation?: Maybe<{ __typename?: 'registrant_Invitation', id: any, inviteCode: any, invitedEmailAddress: string, emails: Array<{ __typename?: 'Email', reason: string }> }> };
 
 export type SelectRegistrantsWithInvitationQueryVariables = Exact<{
   registrantIds: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type SelectRegistrantsWithInvitationQuery = (
-  { __typename?: 'query_root' }
-  & { registrant_Registrant: Array<(
-    { __typename?: 'registrant_Registrant' }
-    & RegistrantWithInvitePartsFragment
-  )> }
-);
+export type SelectRegistrantsWithInvitationQuery = { __typename?: 'query_root', registrant_Registrant: Array<{ __typename?: 'registrant_Registrant', id: any, displayName: string, userId?: Maybe<string>, conference: { __typename?: 'conference_Conference', id: any, name: string, shortName: string, slug: string }, invitation?: Maybe<{ __typename?: 'registrant_Invitation', id: any, inviteCode: any, invitedEmailAddress: string, emails: Array<{ __typename?: 'Email', reason: string }> }> }> };
 
 export type MarkAndSelectUnprocessedInvitationEmailJobsMutationVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MarkAndSelectUnprocessedInvitationEmailJobsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_InvitationEmailJob?: Maybe<(
-    { __typename?: 'job_queues_InvitationEmailJob_mutation_response' }
-    & { returning: Array<(
-      { __typename?: 'job_queues_InvitationEmailJob' }
-      & Pick<Job_Queues_InvitationEmailJob, 'id' | 'registrantIds' | 'sendRepeat'>
-    )> }
-  )> }
-);
+export type MarkAndSelectUnprocessedInvitationEmailJobsMutation = { __typename?: 'mutation_root', update_job_queues_InvitationEmailJob?: Maybe<{ __typename?: 'job_queues_InvitationEmailJob_mutation_response', returning: Array<{ __typename?: 'job_queues_InvitationEmailJob', id: any, registrantIds: any, sendRepeat: boolean }> }> };
 
 export type UnmarkInvitationEmailJobsMutationVariables = Exact<{
   ids: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type UnmarkInvitationEmailJobsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_InvitationEmailJob?: Maybe<(
-    { __typename?: 'job_queues_InvitationEmailJob_mutation_response' }
-    & Pick<Job_Queues_InvitationEmailJob_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type UnmarkInvitationEmailJobsMutation = { __typename?: 'mutation_root', update_job_queues_InvitationEmailJob?: Maybe<{ __typename?: 'job_queues_InvitationEmailJob_mutation_response', affected_rows: number }> };
 
 export type OtherConferencePrepareJobsQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -35759,26 +35297,14 @@ export type OtherConferencePrepareJobsQueryVariables = Exact<{
 }>;
 
 
-export type OtherConferencePrepareJobsQuery = (
-  { __typename?: 'query_root' }
-  & { conference_PrepareJob: Array<(
-    { __typename?: 'conference_PrepareJob' }
-    & Pick<Conference_PrepareJob, 'id' | 'updatedAt'>
-  )> }
-);
+export type OtherConferencePrepareJobsQuery = { __typename?: 'query_root', conference_PrepareJob: Array<{ __typename?: 'conference_PrepareJob', id: any, updatedAt: any }> };
 
 export type GetVideoBroadcastElementsQueryVariables = Exact<{
   conferenceId?: Maybe<Scalars['uuid']>;
 }>;
 
 
-export type GetVideoBroadcastElementsQuery = (
-  { __typename?: 'query_root' }
-  & { content_Element: Array<(
-    { __typename?: 'content_Element' }
-    & Pick<Content_Element, 'id' | 'data'>
-  )> }
-);
+export type GetVideoBroadcastElementsQuery = { __typename?: 'query_root', content_Element: Array<{ __typename?: 'content_Element', id: any, data: any }> };
 
 export type CreateVideoRenderJobMutationVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -35788,47 +35314,21 @@ export type CreateVideoRenderJobMutationVariables = Exact<{
 }>;
 
 
-export type CreateVideoRenderJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_video_VideoRenderJob_one?: Maybe<(
-    { __typename?: 'video_VideoRenderJob' }
-    & Pick<Video_VideoRenderJob, 'id'>
-  )> }
-);
+export type CreateVideoRenderJobMutation = { __typename?: 'mutation_root', insert_video_VideoRenderJob_one?: Maybe<{ __typename?: 'video_VideoRenderJob', id: any }> };
 
 export type GetEventsWithoutVonageSessionQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
 }>;
 
 
-export type GetEventsWithoutVonageSessionQuery = (
-  { __typename?: 'query_root' }
-  & { schedule_Event: Array<(
-    { __typename?: 'schedule_Event' }
-    & Pick<Schedule_Event, 'id'>
-  )> }
-);
+export type GetEventsWithoutVonageSessionQuery = { __typename?: 'query_root', schedule_Event: Array<{ __typename?: 'schedule_Event', id: any }> };
 
 export type Recording_GetEventQueryVariables = Exact<{
   eventId: Scalars['uuid'];
 }>;
 
 
-export type Recording_GetEventQuery = (
-  { __typename?: 'query_root' }
-  & { schedule_Event_by_pk?: Maybe<(
-    { __typename?: 'schedule_Event' }
-    & Pick<Schedule_Event, 'id' | 'startTime' | 'endTime'>
-    & { room: (
-      { __typename?: 'room_Room' }
-      & Pick<Room_Room, 'id'>
-      & { channelStack?: Maybe<(
-        { __typename?: 'video_ChannelStack' }
-        & Pick<Video_ChannelStack, 'id' | 'mediaPackageChannelId'>
-      )> }
-    ) }
-  )> }
-);
+export type Recording_GetEventQuery = { __typename?: 'query_root', schedule_Event_by_pk?: Maybe<{ __typename?: 'schedule_Event', id: any, startTime: any, endTime?: Maybe<any>, room: { __typename?: 'room_Room', id: any, channelStack?: Maybe<{ __typename?: 'video_ChannelStack', id: any, mediaPackageChannelId: string }> } }> };
 
 export type StartMediaPackageHarvestJobMutationVariables = Exact<{
   awsJobId: Scalars['String'];
@@ -35836,13 +35336,7 @@ export type StartMediaPackageHarvestJobMutationVariables = Exact<{
 }>;
 
 
-export type StartMediaPackageHarvestJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_MediaPackageHarvestJob_by_pk?: Maybe<(
-    { __typename?: 'job_queues_MediaPackageHarvestJob' }
-    & Pick<Job_Queues_MediaPackageHarvestJob, 'id'>
-  )> }
-);
+export type StartMediaPackageHarvestJobMutation = { __typename?: 'mutation_root', update_job_queues_MediaPackageHarvestJob_by_pk?: Maybe<{ __typename?: 'job_queues_MediaPackageHarvestJob', id: any }> };
 
 export type CreateMediaPackageHarvestJobMutationVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -35850,34 +35344,14 @@ export type CreateMediaPackageHarvestJobMutationVariables = Exact<{
 }>;
 
 
-export type CreateMediaPackageHarvestJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_job_queues_MediaPackageHarvestJob_one?: Maybe<(
-    { __typename?: 'job_queues_MediaPackageHarvestJob' }
-    & Pick<Job_Queues_MediaPackageHarvestJob, 'id'>
-  )> }
-);
+export type CreateMediaPackageHarvestJobMutation = { __typename?: 'mutation_root', insert_job_queues_MediaPackageHarvestJob_one?: Maybe<{ __typename?: 'job_queues_MediaPackageHarvestJob', id: any }> };
 
 export type Recording_GetMediaPackageHarvestJobQueryVariables = Exact<{
   mediaPackageHarvestJobId: Scalars['String'];
 }>;
 
 
-export type Recording_GetMediaPackageHarvestJobQuery = (
-  { __typename?: 'query_root' }
-  & { job_queues_MediaPackageHarvestJob: Array<(
-    { __typename?: 'job_queues_MediaPackageHarvestJob' }
-    & Pick<Job_Queues_MediaPackageHarvestJob, 'conferenceId' | 'id'>
-    & { event: (
-      { __typename?: 'schedule_Event' }
-      & Pick<Schedule_Event, 'id' | 'name' | 'startTime'>
-      & { item?: Maybe<(
-        { __typename?: 'content_Item' }
-        & Pick<Content_Item, 'id' | 'title'>
-      )> }
-    ) }
-  )> }
-);
+export type Recording_GetMediaPackageHarvestJobQuery = { __typename?: 'query_root', job_queues_MediaPackageHarvestJob: Array<{ __typename?: 'job_queues_MediaPackageHarvestJob', conferenceId: any, id: any, event: { __typename?: 'schedule_Event', id: any, name: string, startTime: any, item?: Maybe<{ __typename?: 'content_Item', id: any, title: string }> } }> };
 
 export type Recording_CompleteMediaPackageHarvestJobMutationVariables = Exact<{
   id: Scalars['uuid'];
@@ -35889,16 +35363,7 @@ export type Recording_CompleteMediaPackageHarvestJobMutationVariables = Exact<{
 }>;
 
 
-export type Recording_CompleteMediaPackageHarvestJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_MediaPackageHarvestJob_by_pk?: Maybe<(
-    { __typename?: 'job_queues_MediaPackageHarvestJob' }
-    & Pick<Job_Queues_MediaPackageHarvestJob, 'id'>
-  )>, insert_content_Element_one?: Maybe<(
-    { __typename?: 'content_Element' }
-    & Pick<Content_Element, 'id'>
-  )> }
-);
+export type Recording_CompleteMediaPackageHarvestJobMutation = { __typename?: 'mutation_root', update_job_queues_MediaPackageHarvestJob_by_pk?: Maybe<{ __typename?: 'job_queues_MediaPackageHarvestJob', id: any }>, insert_content_Element_one?: Maybe<{ __typename?: 'content_Element', id: any }> };
 
 export type Recording_IgnoreMediaPackageHarvestJobMutationVariables = Exact<{
   id: Scalars['uuid'];
@@ -35906,13 +35371,7 @@ export type Recording_IgnoreMediaPackageHarvestJobMutationVariables = Exact<{
 }>;
 
 
-export type Recording_IgnoreMediaPackageHarvestJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_MediaPackageHarvestJob_by_pk?: Maybe<(
-    { __typename?: 'job_queues_MediaPackageHarvestJob' }
-    & Pick<Job_Queues_MediaPackageHarvestJob, 'id'>
-  )> }
-);
+export type Recording_IgnoreMediaPackageHarvestJobMutation = { __typename?: 'mutation_root', update_job_queues_MediaPackageHarvestJob_by_pk?: Maybe<{ __typename?: 'job_queues_MediaPackageHarvestJob', id: any }> };
 
 export type FailMediaPackageHarvestJobMutationVariables = Exact<{
   awsJobId: Scalars['String'];
@@ -35920,26 +35379,14 @@ export type FailMediaPackageHarvestJobMutationVariables = Exact<{
 }>;
 
 
-export type FailMediaPackageHarvestJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_MediaPackageHarvestJob?: Maybe<(
-    { __typename?: 'job_queues_MediaPackageHarvestJob_mutation_response' }
-    & Pick<Job_Queues_MediaPackageHarvestJob_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type FailMediaPackageHarvestJobMutation = { __typename?: 'mutation_root', update_job_queues_MediaPackageHarvestJob?: Maybe<{ __typename?: 'job_queues_MediaPackageHarvestJob_mutation_response', affected_rows: number }> };
 
 export type RegistrantGoogleAccount_GetRegistrantGoogleAccountQueryVariables = Exact<{
   id: Scalars['uuid'];
 }>;
 
 
-export type RegistrantGoogleAccount_GetRegistrantGoogleAccountQuery = (
-  { __typename?: 'query_root' }
-  & { registrant_GoogleAccount_by_pk?: Maybe<(
-    { __typename?: 'registrant_GoogleAccount' }
-    & Pick<Registrant_GoogleAccount, 'registrantId' | 'id' | 'tokenData' | 'youTubeData'>
-  )> }
-);
+export type RegistrantGoogleAccount_GetRegistrantGoogleAccountQuery = { __typename?: 'query_root', registrant_GoogleAccount_by_pk?: Maybe<{ __typename?: 'registrant_GoogleAccount', registrantId: any, id: any, tokenData: any, youTubeData?: Maybe<any> }> };
 
 export type RegistrantGoogleAccount_UpdateRegistrantGoogleAccountMutationVariables = Exact<{
   registrantGoogleAccountId: Scalars['uuid'];
@@ -35947,13 +35394,7 @@ export type RegistrantGoogleAccount_UpdateRegistrantGoogleAccountMutationVariabl
 }>;
 
 
-export type RegistrantGoogleAccount_UpdateRegistrantGoogleAccountMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_registrant_GoogleAccount_by_pk?: Maybe<(
-    { __typename?: 'registrant_GoogleAccount' }
-    & Pick<Registrant_GoogleAccount, 'id'>
-  )> }
-);
+export type RegistrantGoogleAccount_UpdateRegistrantGoogleAccountMutation = { __typename?: 'mutation_root', update_registrant_GoogleAccount_by_pk?: Maybe<{ __typename?: 'registrant_GoogleAccount', id: any }> };
 
 export type SetRoomVonageSessionIdMutationVariables = Exact<{
   roomId: Scalars['uuid'];
@@ -35961,13 +35402,7 @@ export type SetRoomVonageSessionIdMutationVariables = Exact<{
 }>;
 
 
-export type SetRoomVonageSessionIdMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_room_Room_by_pk?: Maybe<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id'>
-  )> }
-);
+export type SetRoomVonageSessionIdMutation = { __typename?: 'mutation_root', update_room_Room_by_pk?: Maybe<{ __typename?: 'room_Room', id: any }> };
 
 export type GetRegistrantsForRoomAndUserQueryVariables = Exact<{
   roomId: Scalars['uuid'];
@@ -35975,21 +35410,7 @@ export type GetRegistrantsForRoomAndUserQueryVariables = Exact<{
 }>;
 
 
-export type GetRegistrantsForRoomAndUserQuery = (
-  { __typename?: 'query_root' }
-  & { room_Room_by_pk?: Maybe<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id'>
-    & { conference: (
-      { __typename?: 'conference_Conference' }
-      & Pick<Conference_Conference, 'id'>
-      & { registrants: Array<(
-        { __typename?: 'registrant_Registrant' }
-        & Pick<Registrant_Registrant, 'userId' | 'id'>
-      )> }
-    ) }
-  )> }
-);
+export type GetRegistrantsForRoomAndUserQuery = { __typename?: 'query_root', room_Room_by_pk?: Maybe<{ __typename?: 'room_Room', id: any, conference: { __typename?: 'conference_Conference', id: any, registrants: Array<{ __typename?: 'registrant_Registrant', userId?: Maybe<string>, id: any }> } }> };
 
 export type AddRegistrantToRoomPeopleMutationVariables = Exact<{
   registrantId: Scalars['uuid'];
@@ -35998,13 +35419,7 @@ export type AddRegistrantToRoomPeopleMutationVariables = Exact<{
 }>;
 
 
-export type AddRegistrantToRoomPeopleMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_room_RoomPerson_one?: Maybe<(
-    { __typename?: 'room_RoomPerson' }
-    & Pick<Room_RoomPerson, 'id'>
-  )> }
-);
+export type AddRegistrantToRoomPeopleMutation = { __typename?: 'mutation_root', insert_room_RoomPerson_one?: Maybe<{ __typename?: 'room_RoomPerson', id: any }> };
 
 export type CreateDmRoom_GetRegistrantsQueryVariables = Exact<{
   registrantIds?: Maybe<Array<Scalars['uuid']> | Scalars['uuid']>;
@@ -36012,13 +35427,7 @@ export type CreateDmRoom_GetRegistrantsQueryVariables = Exact<{
 }>;
 
 
-export type CreateDmRoom_GetRegistrantsQuery = (
-  { __typename?: 'query_root' }
-  & { registrant_Registrant: Array<(
-    { __typename?: 'registrant_Registrant' }
-    & Pick<Registrant_Registrant, 'id' | 'displayName'>
-  )> }
-);
+export type CreateDmRoom_GetRegistrantsQuery = { __typename?: 'query_root', registrant_Registrant: Array<{ __typename?: 'registrant_Registrant', id: any, displayName: string }> };
 
 export type CreateDmRoom_GetExistingRoomsQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -36026,17 +35435,7 @@ export type CreateDmRoom_GetExistingRoomsQueryVariables = Exact<{
 }>;
 
 
-export type CreateDmRoom_GetExistingRoomsQuery = (
-  { __typename?: 'query_root' }
-  & { room_Room: Array<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id' | 'chatId'>
-    & { roomPeople: Array<(
-      { __typename?: 'room_RoomPerson' }
-      & Pick<Room_RoomPerson, 'registrantId' | 'id'>
-    )> }
-  )> }
-);
+export type CreateDmRoom_GetExistingRoomsQuery = { __typename?: 'query_root', room_Room: Array<{ __typename?: 'room_Room', id: any, chatId?: Maybe<any>, roomPeople: Array<{ __typename?: 'room_RoomPerson', registrantId: any, id: any }> }> };
 
 export type CreateDmRoomMutationVariables = Exact<{
   capacity: Scalars['Int'];
@@ -36046,49 +35445,13 @@ export type CreateDmRoomMutationVariables = Exact<{
 }>;
 
 
-export type CreateDmRoomMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_room_Room_one?: Maybe<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id' | 'chatId'>
-  )> }
-);
+export type CreateDmRoomMutation = { __typename?: 'mutation_root', insert_room_Room_one?: Maybe<{ __typename?: 'room_Room', id: any, chatId?: Maybe<any> }> };
 
-export type UnallocatedShuffleQueueEntryFragment = (
-  { __typename?: 'room_ShuffleQueueEntry' }
-  & Pick<Room_ShuffleQueueEntry, 'registrantId' | 'id' | 'created_at'>
-);
+export type UnallocatedShuffleQueueEntryFragment = { __typename?: 'room_ShuffleQueueEntry', registrantId: any, id: any, created_at: any };
 
-export type ActiveShuffleRoomFragment = (
-  { __typename?: 'room_ShuffleRoom' }
-  & Pick<Room_ShuffleRoom, 'id' | 'startedAt' | 'durationMinutes'>
-  & { room: (
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id'>
-    & { people: Array<(
-      { __typename?: 'room_RoomPerson' }
-      & Pick<Room_RoomPerson, 'id' | 'registrantId'>
-    )>, participants: Array<(
-      { __typename?: 'room_Participant' }
-      & Pick<Room_Participant, 'id' | 'registrantId'>
-    )> }
-  ) }
-);
+export type ActiveShuffleRoomFragment = { __typename?: 'room_ShuffleRoom', id: any, startedAt: any, durationMinutes: number, room: { __typename?: 'room_Room', id: any, people: Array<{ __typename?: 'room_RoomPerson', id: any, registrantId: any }>, participants: Array<{ __typename?: 'room_Participant', id: any, registrantId: any }> } };
 
-export type ActiveShufflePeriodFragment = (
-  { __typename?: 'room_ShufflePeriod' }
-  & Pick<Room_ShufflePeriod, 'conferenceId' | 'endAt' | 'id' | 'maxRegistrantsPerRoom' | 'name' | 'organiserId' | 'roomDurationMinutes' | 'startAt' | 'targetRegistrantsPerRoom' | 'waitRoomMaxDurationSeconds' | 'algorithm'>
-  & { unallocatedQueueEntries: Array<(
-    { __typename?: 'room_ShuffleQueueEntry' }
-    & UnallocatedShuffleQueueEntryFragment
-  )>, activeRooms: Array<(
-    { __typename?: 'room_ShuffleRoom' }
-    & ActiveShuffleRoomFragment
-  )>, events: Array<(
-    { __typename?: 'schedule_Event' }
-    & Pick<Schedule_Event, 'id' | 'endTime'>
-  )> }
-);
+export type ActiveShufflePeriodFragment = { __typename?: 'room_ShufflePeriod', conferenceId: any, endAt: any, id: any, maxRegistrantsPerRoom: number, name: string, organiserId: any, roomDurationMinutes: number, startAt: any, targetRegistrantsPerRoom: number, waitRoomMaxDurationSeconds: number, algorithm: Room_ShuffleAlgorithm_Enum, unallocatedQueueEntries: Array<{ __typename?: 'room_ShuffleQueueEntry', registrantId: any, id: any, created_at: any }>, activeRooms: Array<{ __typename?: 'room_ShuffleRoom', id: any, startedAt: any, durationMinutes: number, room: { __typename?: 'room_Room', id: any, people: Array<{ __typename?: 'room_RoomPerson', id: any, registrantId: any }>, participants: Array<{ __typename?: 'room_Participant', id: any, registrantId: any }> } }>, events: Array<{ __typename?: 'schedule_Event', id: any, endTime?: Maybe<any> }> };
 
 export type SelectShufflePeriodQueryVariables = Exact<{
   id: Scalars['uuid'];
@@ -36096,13 +35459,7 @@ export type SelectShufflePeriodQueryVariables = Exact<{
 }>;
 
 
-export type SelectShufflePeriodQuery = (
-  { __typename?: 'query_root' }
-  & { room_ShufflePeriod_by_pk?: Maybe<(
-    { __typename?: 'room_ShufflePeriod' }
-    & ActiveShufflePeriodFragment
-  )> }
-);
+export type SelectShufflePeriodQuery = { __typename?: 'query_root', room_ShufflePeriod_by_pk?: Maybe<{ __typename?: 'room_ShufflePeriod', conferenceId: any, endAt: any, id: any, maxRegistrantsPerRoom: number, name: string, organiserId: any, roomDurationMinutes: number, startAt: any, targetRegistrantsPerRoom: number, waitRoomMaxDurationSeconds: number, algorithm: Room_ShuffleAlgorithm_Enum, unallocatedQueueEntries: Array<{ __typename?: 'room_ShuffleQueueEntry', registrantId: any, id: any, created_at: any }>, activeRooms: Array<{ __typename?: 'room_ShuffleRoom', id: any, startedAt: any, durationMinutes: number, room: { __typename?: 'room_Room', id: any, people: Array<{ __typename?: 'room_RoomPerson', id: any, registrantId: any }>, participants: Array<{ __typename?: 'room_Participant', id: any, registrantId: any }> } }>, events: Array<{ __typename?: 'schedule_Event', id: any, endTime?: Maybe<any> }> }> };
 
 export type SelectActiveShufflePeriodsQueryVariables = Exact<{
   from: Scalars['timestamptz'];
@@ -36111,13 +35468,7 @@ export type SelectActiveShufflePeriodsQueryVariables = Exact<{
 }>;
 
 
-export type SelectActiveShufflePeriodsQuery = (
-  { __typename?: 'query_root' }
-  & { room_ShufflePeriod: Array<(
-    { __typename?: 'room_ShufflePeriod' }
-    & ActiveShufflePeriodFragment
-  )> }
-);
+export type SelectActiveShufflePeriodsQuery = { __typename?: 'query_root', room_ShufflePeriod: Array<{ __typename?: 'room_ShufflePeriod', conferenceId: any, endAt: any, id: any, maxRegistrantsPerRoom: number, name: string, organiserId: any, roomDurationMinutes: number, startAt: any, targetRegistrantsPerRoom: number, waitRoomMaxDurationSeconds: number, algorithm: Room_ShuffleAlgorithm_Enum, unallocatedQueueEntries: Array<{ __typename?: 'room_ShuffleQueueEntry', registrantId: any, id: any, created_at: any }>, activeRooms: Array<{ __typename?: 'room_ShuffleRoom', id: any, startedAt: any, durationMinutes: number, room: { __typename?: 'room_Room', id: any, people: Array<{ __typename?: 'room_RoomPerson', id: any, registrantId: any }>, participants: Array<{ __typename?: 'room_Participant', id: any, registrantId: any }> } }>, events: Array<{ __typename?: 'schedule_Event', id: any, endTime?: Maybe<any> }> }> };
 
 export type AddPeopleToExistingShuffleRoomMutationVariables = Exact<{
   shuffleRoomId: Scalars['Int'];
@@ -36126,37 +35477,14 @@ export type AddPeopleToExistingShuffleRoomMutationVariables = Exact<{
 }>;
 
 
-export type AddPeopleToExistingShuffleRoomMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_room_RoomPerson?: Maybe<(
-    { __typename?: 'room_RoomPerson_mutation_response' }
-    & Pick<Room_RoomPerson_Mutation_Response, 'affected_rows'>
-  )>, update_room_ShuffleQueueEntry?: Maybe<(
-    { __typename?: 'room_ShuffleQueueEntry_mutation_response' }
-    & Pick<Room_ShuffleQueueEntry_Mutation_Response, 'affected_rows'>
-    & { returning: Array<(
-      { __typename?: 'room_ShuffleQueueEntry' }
-      & Pick<Room_ShuffleQueueEntry, 'id'>
-    )> }
-  )> }
-);
+export type AddPeopleToExistingShuffleRoomMutation = { __typename?: 'mutation_root', insert_room_RoomPerson?: Maybe<{ __typename?: 'room_RoomPerson_mutation_response', affected_rows: number }>, update_room_ShuffleQueueEntry?: Maybe<{ __typename?: 'room_ShuffleQueueEntry_mutation_response', affected_rows: number, returning: Array<{ __typename?: 'room_ShuffleQueueEntry', id: any }> }> };
 
 export type ExpireShuffleQueueEntriesMutationVariables = Exact<{
   queueEntryIds: Array<Scalars['bigint']> | Scalars['bigint'];
 }>;
 
 
-export type ExpireShuffleQueueEntriesMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_room_ShuffleQueueEntry?: Maybe<(
-    { __typename?: 'room_ShuffleQueueEntry_mutation_response' }
-    & Pick<Room_ShuffleQueueEntry_Mutation_Response, 'affected_rows'>
-    & { returning: Array<(
-      { __typename?: 'room_ShuffleQueueEntry' }
-      & Pick<Room_ShuffleQueueEntry, 'id'>
-    )> }
-  )> }
-);
+export type ExpireShuffleQueueEntriesMutation = { __typename?: 'mutation_root', update_room_ShuffleQueueEntry?: Maybe<{ __typename?: 'room_ShuffleQueueEntry_mutation_response', affected_rows: number, returning: Array<{ __typename?: 'room_ShuffleQueueEntry', id: any }> }> };
 
 export type InsertShuffleRoomMutationVariables = Exact<{
   durationMinutes: Scalars['Int'];
@@ -36167,13 +35495,7 @@ export type InsertShuffleRoomMutationVariables = Exact<{
 }>;
 
 
-export type InsertShuffleRoomMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_room_ShuffleRoom_one?: Maybe<(
-    { __typename?: 'room_ShuffleRoom' }
-    & Pick<Room_ShuffleRoom, 'id'>
-  )> }
-);
+export type InsertShuffleRoomMutation = { __typename?: 'mutation_root', insert_room_ShuffleRoom_one?: Maybe<{ __typename?: 'room_ShuffleRoom', id: any }> };
 
 export type InsertManagedRoomMutationVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -36182,96 +35504,39 @@ export type InsertManagedRoomMutationVariables = Exact<{
 }>;
 
 
-export type InsertManagedRoomMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_room_Room_one?: Maybe<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id'>
-  )> }
-);
+export type InsertManagedRoomMutation = { __typename?: 'mutation_root', insert_room_Room_one?: Maybe<{ __typename?: 'room_Room', id: any }> };
 
 export type SetAutoPinOnManagedRoomMutationVariables = Exact<{
   roomId: Scalars['uuid'];
 }>;
 
 
-export type SetAutoPinOnManagedRoomMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_chat_Chat?: Maybe<(
-    { __typename?: 'chat_Chat_mutation_response' }
-    & Pick<Chat_Chat_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type SetAutoPinOnManagedRoomMutation = { __typename?: 'mutation_root', update_chat_Chat?: Maybe<{ __typename?: 'chat_Chat_mutation_response', affected_rows: number }> };
 
 export type SetShuffleRoomsEndedMutationVariables = Exact<{
   ids: Array<Scalars['bigint']> | Scalars['bigint'];
 }>;
 
 
-export type SetShuffleRoomsEndedMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_room_ShuffleRoom?: Maybe<(
-    { __typename?: 'room_ShuffleRoom_mutation_response' }
-    & Pick<Room_ShuffleRoom_Mutation_Response, 'affected_rows'>
-    & { returning: Array<(
-      { __typename?: 'room_ShuffleRoom' }
-      & Pick<Room_ShuffleRoom, 'id'>
-    )> }
-  )> }
-);
+export type SetShuffleRoomsEndedMutation = { __typename?: 'mutation_root', update_room_ShuffleRoom?: Maybe<{ __typename?: 'room_ShuffleRoom_mutation_response', affected_rows: number, returning: Array<{ __typename?: 'room_ShuffleRoom', id: any }> }> };
 
 export type UploadableElementQueryVariables = Exact<{
   accessToken: Scalars['String'];
 }>;
 
 
-export type UploadableElementQuery = (
-  { __typename?: 'query_root' }
-  & { content_Element: Array<(
-    { __typename?: 'content_Element' }
-    & { conference: (
-      { __typename?: 'conference_Conference' }
-      & { configurations: Array<(
-        { __typename?: 'conference_Configuration' }
-        & Pick<Conference_Configuration, 'conferenceId' | 'key' | 'value'>
-      )> }
-    ) }
-    & UploadableElementFieldsFragment
-  )> }
-);
+export type UploadableElementQuery = { __typename?: 'query_root', content_Element: Array<{ __typename?: 'content_Element', id: any, typeName: Content_ElementType_Enum, accessToken: string, name: string, uploadsRemaining?: Maybe<number>, isHidden: boolean, data: any, conference: { __typename?: 'conference_Conference', id: any, name: string, configurations: Array<{ __typename?: 'conference_Configuration', conferenceId: any, key: Conference_ConfigurationKey_Enum, value: any }> }, item: { __typename?: 'content_Item', id: any, title: string }, permissionGrants: Array<{ __typename?: 'content_ElementPermissionGrant', id: any, permissionSetId: any, groupId?: Maybe<any>, entityId?: Maybe<any>, conferenceSlug: string }> }> };
 
-export type UploadableElementPermissionGrantFieldsFragment = (
-  { __typename?: 'content_ElementPermissionGrant' }
-  & Pick<Content_ElementPermissionGrant, 'id' | 'permissionSetId' | 'groupId' | 'entityId' | 'conferenceSlug'>
-);
+export type UploadableElementPermissionGrantFieldsFragment = { __typename?: 'content_ElementPermissionGrant', id: any, permissionSetId: any, groupId?: Maybe<any>, entityId?: Maybe<any>, conferenceSlug: string };
 
-export type UploadableElementFieldsFragment = (
-  { __typename?: 'content_Element' }
-  & Pick<Content_Element, 'id' | 'typeName' | 'accessToken' | 'name' | 'uploadsRemaining' | 'isHidden' | 'data'>
-  & { conference: (
-    { __typename?: 'conference_Conference' }
-    & Pick<Conference_Conference, 'id' | 'name'>
-  ), item: (
-    { __typename?: 'content_Item' }
-    & Pick<Content_Item, 'id' | 'title'>
-  ), permissionGrants: Array<(
-    { __typename?: 'content_ElementPermissionGrant' }
-    & UploadableElementPermissionGrantFieldsFragment
-  )> }
-);
+export type UploadableElementFieldsFragment = { __typename?: 'content_Element', id: any, typeName: Content_ElementType_Enum, accessToken: string, name: string, uploadsRemaining?: Maybe<number>, isHidden: boolean, data: any, conference: { __typename?: 'conference_Conference', id: any, name: string }, item: { __typename?: 'content_Item', id: any, title: string }, permissionGrants: Array<{ __typename?: 'content_ElementPermissionGrant', id: any, permissionSetId: any, groupId?: Maybe<any>, entityId?: Maybe<any>, conferenceSlug: string }> };
 
 export type GetUploadersQueryVariables = Exact<{
   elementId: Scalars['uuid'];
 }>;
 
 
-export type GetUploadersQuery = (
-  { __typename?: 'query_root' }
-  & { content_Uploader: Array<(
-    { __typename?: 'content_Uploader' }
-    & Pick<Content_Uploader, 'name' | 'id' | 'email' | 'conferenceId'>
-  )> }
-);
+export type GetUploadersQuery = { __typename?: 'query_root', content_Uploader: Array<{ __typename?: 'content_Uploader', name: string, id: any, email: string, conferenceId: any }> };
 
 export type SetUploadableElementUploadsRemainingMutationVariables = Exact<{
   id: Scalars['uuid'];
@@ -36279,131 +35544,56 @@ export type SetUploadableElementUploadsRemainingMutationVariables = Exact<{
 }>;
 
 
-export type SetUploadableElementUploadsRemainingMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_content_Element_by_pk?: Maybe<(
-    { __typename?: 'content_Element' }
-    & Pick<Content_Element, 'id'>
-  )> }
-);
+export type SetUploadableElementUploadsRemainingMutation = { __typename?: 'mutation_root', update_content_Element_by_pk?: Maybe<{ __typename?: 'content_Element', id: any }> };
 
-export type UploaderPartsFragment = (
-  { __typename?: 'content_Uploader' }
-  & Pick<Content_Uploader, 'id' | 'email' | 'emailsSentCount' | 'name'>
-  & { conference: (
-    { __typename?: 'conference_Conference' }
-    & Pick<Conference_Conference, 'id' | 'name' | 'shortName'>
-  ), element: (
-    { __typename?: 'content_Element' }
-    & UploadableElementFieldsFragment
-  ) }
-);
+export type UploaderPartsFragment = { __typename?: 'content_Uploader', id: any, email: string, emailsSentCount: number, name: string, conference: { __typename?: 'conference_Conference', id: any, name: string, shortName: string }, element: { __typename?: 'content_Element', id: any, typeName: Content_ElementType_Enum, accessToken: string, name: string, uploadsRemaining?: Maybe<number>, isHidden: boolean, data: any, conference: { __typename?: 'conference_Conference', id: any, name: string }, item: { __typename?: 'content_Item', id: any, title: string }, permissionGrants: Array<{ __typename?: 'content_ElementPermissionGrant', id: any, permissionSetId: any, groupId?: Maybe<any>, entityId?: Maybe<any>, conferenceSlug: string }> } };
 
 export type InsertSubmissionRequestEmailsMutationVariables = Exact<{
   uploaderIds: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type InsertSubmissionRequestEmailsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_content_Uploader?: Maybe<(
-    { __typename?: 'content_Uploader_mutation_response' }
-    & Pick<Content_Uploader_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type InsertSubmissionRequestEmailsMutation = { __typename?: 'mutation_root', update_content_Uploader?: Maybe<{ __typename?: 'content_Uploader_mutation_response', affected_rows: number }> };
 
 export type MarkAndSelectUnprocessedSubmissionRequestEmailJobsMutationVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MarkAndSelectUnprocessedSubmissionRequestEmailJobsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_SubmissionRequestEmailJob?: Maybe<(
-    { __typename?: 'job_queues_SubmissionRequestEmailJob_mutation_response' }
-    & { returning: Array<(
-      { __typename?: 'job_queues_SubmissionRequestEmailJob' }
-      & Pick<Job_Queues_SubmissionRequestEmailJob, 'id' | 'emailTemplate'>
-      & { uploader: (
-        { __typename?: 'content_Uploader' }
-        & UploaderPartsFragment
-      ) }
-    )> }
-  )> }
-);
+export type MarkAndSelectUnprocessedSubmissionRequestEmailJobsMutation = { __typename?: 'mutation_root', update_job_queues_SubmissionRequestEmailJob?: Maybe<{ __typename?: 'job_queues_SubmissionRequestEmailJob_mutation_response', returning: Array<{ __typename?: 'job_queues_SubmissionRequestEmailJob', id: any, emailTemplate?: Maybe<any>, uploader: { __typename?: 'content_Uploader', id: any, email: string, emailsSentCount: number, name: string, conference: { __typename?: 'conference_Conference', id: any, name: string, shortName: string }, element: { __typename?: 'content_Element', id: any, typeName: Content_ElementType_Enum, accessToken: string, name: string, uploadsRemaining?: Maybe<number>, isHidden: boolean, data: any, conference: { __typename?: 'conference_Conference', id: any, name: string }, item: { __typename?: 'content_Item', id: any, title: string }, permissionGrants: Array<{ __typename?: 'content_ElementPermissionGrant', id: any, permissionSetId: any, groupId?: Maybe<any>, entityId?: Maybe<any>, conferenceSlug: string }> } } }> }> };
 
 export type UnmarkSubmissionRequestEmailJobsMutationVariables = Exact<{
   ids: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type UnmarkSubmissionRequestEmailJobsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_job_queues_SubmissionRequestEmailJob?: Maybe<(
-    { __typename?: 'job_queues_SubmissionRequestEmailJob_mutation_response' }
-    & Pick<Job_Queues_SubmissionRequestEmailJob_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type UnmarkSubmissionRequestEmailJobsMutation = { __typename?: 'mutation_root', update_job_queues_SubmissionRequestEmailJob?: Maybe<{ __typename?: 'job_queues_SubmissionRequestEmailJob_mutation_response', affected_rows: number }> };
 
 export type GetElementIdForVideoRenderJobQueryVariables = Exact<{
   videoRenderJobId: Scalars['uuid'];
 }>;
 
 
-export type GetElementIdForVideoRenderJobQuery = (
-  { __typename?: 'query_root' }
-  & { video_VideoRenderJob_by_pk?: Maybe<(
-    { __typename?: 'video_VideoRenderJob' }
-    & Pick<Video_VideoRenderJob, 'elementId' | 'id'>
-  )> }
-);
+export type GetElementIdForVideoRenderJobQuery = { __typename?: 'query_root', video_VideoRenderJob_by_pk?: Maybe<{ __typename?: 'video_VideoRenderJob', elementId: any, id: any }> };
 
 export type SelectNewVideoRenderJobsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SelectNewVideoRenderJobsQuery = (
-  { __typename?: 'query_root' }
-  & { video_VideoRenderJob: Array<(
-    { __typename?: 'video_VideoRenderJob' }
-    & Pick<Video_VideoRenderJob, 'id'>
-  )> }
-);
+export type SelectNewVideoRenderJobsQuery = { __typename?: 'query_root', video_VideoRenderJob: Array<{ __typename?: 'video_VideoRenderJob', id: any }> };
 
 export type MarkAndSelectNewVideoRenderJobsMutationVariables = Exact<{
   ids: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type MarkAndSelectNewVideoRenderJobsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_video_VideoRenderJob?: Maybe<(
-    { __typename?: 'video_VideoRenderJob_mutation_response' }
-    & { returning: Array<(
-      { __typename?: 'video_VideoRenderJob' }
-      & VideoRenderJobDataFragment
-    )> }
-  )> }
-);
+export type MarkAndSelectNewVideoRenderJobsMutation = { __typename?: 'mutation_root', update_video_VideoRenderJob?: Maybe<{ __typename?: 'video_VideoRenderJob_mutation_response', returning: Array<{ __typename?: 'video_VideoRenderJob', id: any, jobStatusName: Video_JobStatus_Enum, data: any, retriesCount: number }> }> };
 
-export type VideoRenderJobDataFragment = (
-  { __typename?: 'video_VideoRenderJob' }
-  & Pick<Video_VideoRenderJob, 'id' | 'jobStatusName' | 'data' | 'retriesCount'>
-);
+export type VideoRenderJobDataFragment = { __typename?: 'video_VideoRenderJob', id: any, jobStatusName: Video_JobStatus_Enum, data: any, retriesCount: number };
 
 export type UnmarkVideoRenderJobsMutationVariables = Exact<{
   ids: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type UnmarkVideoRenderJobsMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_video_VideoRenderJob?: Maybe<(
-    { __typename?: 'video_VideoRenderJob_mutation_response' }
-    & Pick<Video_VideoRenderJob_Mutation_Response, 'affected_rows'>
-    & { returning: Array<(
-      { __typename?: 'video_VideoRenderJob' }
-      & Pick<Video_VideoRenderJob, 'id'>
-    )> }
-  )> }
-);
+export type UnmarkVideoRenderJobsMutation = { __typename?: 'mutation_root', update_video_VideoRenderJob?: Maybe<{ __typename?: 'video_VideoRenderJob_mutation_response', affected_rows: number, returning: Array<{ __typename?: 'video_VideoRenderJob', id: any }> }> };
 
 export type OngoingBroadcastableVideoRoomEventsQueryVariables = Exact<{
   time: Scalars['timestamptz'];
@@ -36411,30 +35601,14 @@ export type OngoingBroadcastableVideoRoomEventsQueryVariables = Exact<{
 }>;
 
 
-export type OngoingBroadcastableVideoRoomEventsQuery = (
-  { __typename?: 'query_root' }
-  & { schedule_Event: Array<(
-    { __typename?: 'schedule_Event' }
-    & Pick<Schedule_Event, 'id'>
-  )> }
-);
+export type OngoingBroadcastableVideoRoomEventsQuery = { __typename?: 'query_root', schedule_Event: Array<{ __typename?: 'schedule_Event', id: any }> };
 
 export type Vonage_GetEventDetailsQueryVariables = Exact<{
   eventId: Scalars['uuid'];
 }>;
 
 
-export type Vonage_GetEventDetailsQuery = (
-  { __typename?: 'query_root' }
-  & { schedule_Event_by_pk?: Maybe<(
-    { __typename?: 'schedule_Event' }
-    & Pick<Schedule_Event, 'conferenceId' | 'id'>
-    & { eventVonageSession?: Maybe<(
-      { __typename?: 'video_EventVonageSession' }
-      & Pick<Video_EventVonageSession, 'id' | 'sessionId'>
-    )> }
-  )> }
-);
+export type Vonage_GetEventDetailsQuery = { __typename?: 'query_root', schedule_Event_by_pk?: Maybe<{ __typename?: 'schedule_Event', conferenceId: any, id: any, eventVonageSession?: Maybe<{ __typename?: 'video_EventVonageSession', id: any, sessionId: string }> }> };
 
 export type GetRoomThatUserCanJoinQueryVariables = Exact<{
   roomId?: Maybe<Scalars['uuid']>;
@@ -36442,37 +35616,19 @@ export type GetRoomThatUserCanJoinQueryVariables = Exact<{
 }>;
 
 
-export type GetRoomThatUserCanJoinQuery = (
-  { __typename?: 'query_root' }
-  & { room_Room_by_pk?: Maybe<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id' | 'publicVonageSessionId'>
-  )> }
-);
+export type GetRoomThatUserCanJoinQuery = { __typename?: 'query_root', room_Room_by_pk?: Maybe<{ __typename?: 'room_Room', id: any, publicVonageSessionId?: Maybe<string> }> };
 
 export type FetchPresenceSummaryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type FetchPresenceSummaryQuery = (
-  { __typename?: 'query_root' }
-  & { presence_Summary?: Maybe<(
-    { __typename?: 'PresenceSummaryOutput' }
-    & Pick<PresenceSummaryOutput, 'total_unique_tabs' | 'total_unique_user_ids' | 'pages'>
-  )> }
-);
+export type FetchPresenceSummaryQuery = { __typename?: 'query_root', presence_Summary?: Maybe<{ __typename?: 'PresenceSummaryOutput', total_unique_tabs: number, total_unique_user_ids: number, pages?: Maybe<any> }> };
 
 export type InsertAppStatsMutationVariables = Exact<{
   object: Analytics_AppStats_Insert_Input;
 }>;
 
 
-export type InsertAppStatsMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_analytics_AppStats_one?: Maybe<(
-    { __typename?: 'analytics_AppStats' }
-    & Pick<Analytics_AppStats, 'id'>
-  )> }
-);
+export type InsertAppStatsMutation = { __typename?: 'mutation_root', insert_analytics_AppStats_one?: Maybe<{ __typename?: 'analytics_AppStats', id: number }> };
 
 export type GetRegistrantQueryVariables = Exact<{
   userId: Scalars['String'];
@@ -36480,18 +35636,9 @@ export type GetRegistrantQueryVariables = Exact<{
 }>;
 
 
-export type GetRegistrantQuery = (
-  { __typename?: 'query_root' }
-  & { registrant_Registrant: Array<(
-    { __typename?: 'registrant_Registrant' }
-    & GetRegistrant_RegistrantFragment
-  )> }
-);
+export type GetRegistrantQuery = { __typename?: 'query_root', registrant_Registrant: Array<{ __typename?: 'registrant_Registrant', id: any, displayName: string, conferenceId: any }> };
 
-export type GetRegistrant_RegistrantFragment = (
-  { __typename?: 'registrant_Registrant' }
-  & Pick<Registrant_Registrant, 'id' | 'displayName' | 'conferenceId'>
-);
+export type GetRegistrant_RegistrantFragment = { __typename?: 'registrant_Registrant', id: any, displayName: string, conferenceId: any };
 
 export type GetRegistrantByConferenceSlugQueryVariables = Exact<{
   userId: Scalars['String'];
@@ -36499,13 +35646,7 @@ export type GetRegistrantByConferenceSlugQueryVariables = Exact<{
 }>;
 
 
-export type GetRegistrantByConferenceSlugQuery = (
-  { __typename?: 'query_root' }
-  & { registrant_Registrant: Array<(
-    { __typename?: 'registrant_Registrant' }
-    & GetRegistrant_RegistrantFragment
-  )> }
-);
+export type GetRegistrantByConferenceSlugQuery = { __typename?: 'query_root', registrant_Registrant: Array<{ __typename?: 'registrant_Registrant', id: any, displayName: string, conferenceId: any }> };
 
 export type Authorisation_FindRegistrantQueryVariables = Exact<{
   registrantId: Scalars['uuid'];
@@ -36513,13 +35654,7 @@ export type Authorisation_FindRegistrantQueryVariables = Exact<{
 }>;
 
 
-export type Authorisation_FindRegistrantQuery = (
-  { __typename?: 'query_root' }
-  & { registrant_Registrant: Array<(
-    { __typename?: 'registrant_Registrant' }
-    & GetRegistrant_RegistrantFragment
-  )> }
-);
+export type Authorisation_FindRegistrantQuery = { __typename?: 'query_root', registrant_Registrant: Array<{ __typename?: 'registrant_Registrant', id: any, displayName: string, conferenceId: any }> };
 
 export type GetConfigurationValueQueryVariables = Exact<{
   key: Conference_ConfigurationKey_Enum;
@@ -36527,13 +35662,7 @@ export type GetConfigurationValueQueryVariables = Exact<{
 }>;
 
 
-export type GetConfigurationValueQuery = (
-  { __typename?: 'query_root' }
-  & { conference_Configuration_by_pk?: Maybe<(
-    { __typename?: 'conference_Configuration' }
-    & Pick<Conference_Configuration, 'key' | 'value'>
-  )> }
-);
+export type GetConfigurationValueQuery = { __typename?: 'query_root', conference_Configuration_by_pk?: Maybe<{ __typename?: 'conference_Configuration', key: Conference_ConfigurationKey_Enum, value: any }> };
 
 export type FailConferencePrepareJobMutationVariables = Exact<{
   id: Scalars['uuid'];
@@ -36541,52 +35670,28 @@ export type FailConferencePrepareJobMutationVariables = Exact<{
 }>;
 
 
-export type FailConferencePrepareJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_conference_PrepareJob_by_pk?: Maybe<(
-    { __typename?: 'conference_PrepareJob' }
-    & Pick<Conference_PrepareJob, 'id'>
-  )> }
-);
+export type FailConferencePrepareJobMutation = { __typename?: 'mutation_root', update_conference_PrepareJob_by_pk?: Maybe<{ __typename?: 'conference_PrepareJob', id: any }> };
 
 export type CompleteConferencePrepareJobMutationVariables = Exact<{
   id: Scalars['uuid'];
 }>;
 
 
-export type CompleteConferencePrepareJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_conference_PrepareJob_by_pk?: Maybe<(
-    { __typename?: 'conference_PrepareJob' }
-    & Pick<Conference_PrepareJob, 'id'>
-  )> }
-);
+export type CompleteConferencePrepareJobMutation = { __typename?: 'mutation_root', update_conference_PrepareJob_by_pk?: Maybe<{ __typename?: 'conference_PrepareJob', id: any }> };
 
 export type GetElementByIdQueryVariables = Exact<{
   elementId: Scalars['uuid'];
 }>;
 
 
-export type GetElementByIdQuery = (
-  { __typename?: 'query_root' }
-  & { content_Element_by_pk?: Maybe<(
-    { __typename?: 'content_Element' }
-    & Pick<Content_Element, 'id' | 'data' | 'typeName'>
-  )> }
-);
+export type GetElementByIdQuery = { __typename?: 'query_root', content_Element_by_pk?: Maybe<{ __typename?: 'content_Element', id: any, data: any, typeName: Content_ElementType_Enum }> };
 
 export type GetEventVonageSessionQueryVariables = Exact<{
   eventId: Scalars['uuid'];
 }>;
 
 
-export type GetEventVonageSessionQuery = (
-  { __typename?: 'query_root' }
-  & { video_EventVonageSession: Array<(
-    { __typename?: 'video_EventVonageSession' }
-    & Pick<Video_EventVonageSession, 'id'>
-  )> }
-);
+export type GetEventVonageSessionQuery = { __typename?: 'query_root', video_EventVonageSession: Array<{ __typename?: 'video_EventVonageSession', id: any }> };
 
 export type SetEventVonageSessionIdMutationVariables = Exact<{
   eventId: Scalars['uuid'];
@@ -36595,30 +35700,14 @@ export type SetEventVonageSessionIdMutationVariables = Exact<{
 }>;
 
 
-export type SetEventVonageSessionIdMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_video_EventVonageSession_one?: Maybe<(
-    { __typename?: 'video_EventVonageSession' }
-    & Pick<Video_EventVonageSession, 'id'>
-  )> }
-);
+export type SetEventVonageSessionIdMutation = { __typename?: 'mutation_root', insert_video_EventVonageSession_one?: Maybe<{ __typename?: 'video_EventVonageSession', id: any }> };
 
 export type CreateItemRoom_GetItemQueryVariables = Exact<{
   id: Scalars['uuid'];
 }>;
 
 
-export type CreateItemRoom_GetItemQuery = (
-  { __typename?: 'query_root' }
-  & { content_Item_by_pk?: Maybe<(
-    { __typename?: 'content_Item' }
-    & Pick<Content_Item, 'id' | 'chatId' | 'conferenceId' | 'title'>
-    & { rooms: Array<(
-      { __typename?: 'room_Room' }
-      & Pick<Room_Room, 'id'>
-    )> }
-  )> }
-);
+export type CreateItemRoom_GetItemQuery = { __typename?: 'query_root', content_Item_by_pk?: Maybe<{ __typename?: 'content_Item', id: any, chatId?: Maybe<any>, conferenceId: any, title: string, rooms: Array<{ __typename?: 'room_Room', id: any }> }> };
 
 export type Item_CreateRoomMutationVariables = Exact<{
   chatId?: Maybe<Scalars['uuid']>;
@@ -36628,26 +35717,14 @@ export type Item_CreateRoomMutationVariables = Exact<{
 }>;
 
 
-export type Item_CreateRoomMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_room_Room_one?: Maybe<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id'>
-  )> }
-);
+export type Item_CreateRoomMutation = { __typename?: 'mutation_root', insert_room_Room_one?: Maybe<{ __typename?: 'room_Room', id: any }> };
 
 export type GetRoomConferenceIdQueryVariables = Exact<{
   roomId: Scalars['uuid'];
 }>;
 
 
-export type GetRoomConferenceIdQuery = (
-  { __typename?: 'query_root' }
-  & { room_Room_by_pk?: Maybe<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id' | 'conferenceId'>
-  )> }
-);
+export type GetRoomConferenceIdQuery = { __typename?: 'query_root', room_Room_by_pk?: Maybe<{ __typename?: 'room_Room', id: any, conferenceId: any }> };
 
 export type GetRoomThatRegistrantCanJoinQueryVariables = Exact<{
   roomId?: Maybe<Scalars['uuid']>;
@@ -36656,23 +35733,7 @@ export type GetRoomThatRegistrantCanJoinQueryVariables = Exact<{
 }>;
 
 
-export type GetRoomThatRegistrantCanJoinQuery = (
-  { __typename?: 'query_root' }
-  & { room_Room: Array<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id' | 'publicVonageSessionId'>
-    & { conference: (
-      { __typename?: 'conference_Conference' }
-      & { registrants: Array<(
-        { __typename?: 'registrant_Registrant' }
-        & Pick<Registrant_Registrant, 'id'>
-      )> }
-    ) }
-  )>, FlatUserPermission: Array<(
-    { __typename?: 'FlatUserPermission' }
-    & Pick<FlatUserPermission, 'permission_name'>
-  )> }
-);
+export type GetRoomThatRegistrantCanJoinQuery = { __typename?: 'query_root', room_Room: Array<{ __typename?: 'room_Room', id: any, publicVonageSessionId?: Maybe<string>, conference: { __typename?: 'conference_Conference', registrants: Array<{ __typename?: 'registrant_Registrant', id: any }> } }>, FlatUserPermission: Array<{ __typename?: 'FlatUserPermission', permission_name?: Maybe<string> }> };
 
 export type CreateRoomChimeMeetingMutationVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -36682,78 +35743,42 @@ export type CreateRoomChimeMeetingMutationVariables = Exact<{
 }>;
 
 
-export type CreateRoomChimeMeetingMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_room_ChimeMeeting_one?: Maybe<(
-    { __typename?: 'room_ChimeMeeting' }
-    & Pick<Room_ChimeMeeting, 'id'>
-  )> }
-);
+export type CreateRoomChimeMeetingMutation = { __typename?: 'mutation_root', insert_room_ChimeMeeting_one?: Maybe<{ __typename?: 'room_ChimeMeeting', id: any }> };
 
 export type GetRoomChimeMeetingQueryVariables = Exact<{
   roomId: Scalars['uuid'];
 }>;
 
 
-export type GetRoomChimeMeetingQuery = (
-  { __typename?: 'query_root' }
-  & { room_ChimeMeeting: Array<(
-    { __typename?: 'room_ChimeMeeting' }
-    & Pick<Room_ChimeMeeting, 'id' | 'chimeMeetingData'>
-  )> }
-);
+export type GetRoomChimeMeetingQuery = { __typename?: 'query_root', room_ChimeMeeting: Array<{ __typename?: 'room_ChimeMeeting', id: any, chimeMeetingData: any }> };
 
 export type GetRoomVonageMeetingQueryVariables = Exact<{
   roomId: Scalars['uuid'];
 }>;
 
 
-export type GetRoomVonageMeetingQuery = (
-  { __typename?: 'query_root' }
-  & { room_Room_by_pk?: Maybe<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id' | 'publicVonageSessionId'>
-  )> }
-);
+export type GetRoomVonageMeetingQuery = { __typename?: 'query_root', room_Room_by_pk?: Maybe<{ __typename?: 'room_Room', id: any, publicVonageSessionId?: Maybe<string> }> };
 
 export type GetRoomBySessionIdQueryVariables = Exact<{
   sessionId: Scalars['String'];
 }>;
 
 
-export type GetRoomBySessionIdQuery = (
-  { __typename?: 'query_root' }
-  & { room_Room: Array<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id' | 'conferenceId'>
-  )> }
-);
+export type GetRoomBySessionIdQuery = { __typename?: 'query_root', room_Room: Array<{ __typename?: 'room_Room', id: any, conferenceId: any }> };
 
 export type GetRoomByChimeMeetingIdQueryVariables = Exact<{
   meetingId: Scalars['String'];
 }>;
 
 
-export type GetRoomByChimeMeetingIdQuery = (
-  { __typename?: 'query_root' }
-  & { room_Room: Array<(
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id' | 'conferenceId'>
-  )> }
-);
+export type GetRoomByChimeMeetingIdQuery = { __typename?: 'query_root', room_Room: Array<{ __typename?: 'room_Room', id: any, conferenceId: any }> };
 
 export type DeleteRoomChimeMeetingMutationVariables = Exact<{
   chimeMeetingId: Scalars['uuid'];
 }>;
 
 
-export type DeleteRoomChimeMeetingMutation = (
-  { __typename?: 'mutation_root' }
-  & { delete_room_ChimeMeeting_by_pk?: Maybe<(
-    { __typename?: 'room_ChimeMeeting' }
-    & Pick<Room_ChimeMeeting, 'id'>
-  )> }
-);
+export type DeleteRoomChimeMeetingMutation = { __typename?: 'mutation_root', delete_room_ChimeMeeting_by_pk?: Maybe<{ __typename?: 'room_ChimeMeeting', id: any }> };
 
 export type DeleteRoomChimeMeetingForRoomMutationVariables = Exact<{
   roomId: Scalars['uuid'];
@@ -36761,13 +35786,7 @@ export type DeleteRoomChimeMeetingForRoomMutationVariables = Exact<{
 }>;
 
 
-export type DeleteRoomChimeMeetingForRoomMutation = (
-  { __typename?: 'mutation_root' }
-  & { delete_room_ChimeMeeting?: Maybe<(
-    { __typename?: 'room_ChimeMeeting_mutation_response' }
-    & Pick<Room_ChimeMeeting_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type DeleteRoomChimeMeetingForRoomMutation = { __typename?: 'mutation_root', delete_room_ChimeMeeting?: Maybe<{ __typename?: 'room_ChimeMeeting_mutation_response', affected_rows: number }> };
 
 export type CreateRoomParticipantMutationVariables = Exact<{
   registrantId: Scalars['uuid'];
@@ -36778,13 +35797,7 @@ export type CreateRoomParticipantMutationVariables = Exact<{
 }>;
 
 
-export type CreateRoomParticipantMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_room_Participant_one?: Maybe<(
-    { __typename?: 'room_Participant' }
-    & Pick<Room_Participant, 'id'>
-  )> }
-);
+export type CreateRoomParticipantMutation = { __typename?: 'mutation_root', insert_room_Participant_one?: Maybe<{ __typename?: 'room_Participant', id: any }> };
 
 export type RemoveRoomParticipantMutationVariables = Exact<{
   registrantId: Scalars['uuid'];
@@ -36795,13 +35808,7 @@ export type RemoveRoomParticipantMutationVariables = Exact<{
 }>;
 
 
-export type RemoveRoomParticipantMutation = (
-  { __typename?: 'mutation_root' }
-  & { delete_room_Participant?: Maybe<(
-    { __typename?: 'room_Participant_mutation_response' }
-    & Pick<Room_Participant_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type RemoveRoomParticipantMutation = { __typename?: 'mutation_root', delete_room_Participant?: Maybe<{ __typename?: 'room_Participant_mutation_response', affected_rows: number }> };
 
 export type GetRoomParticipantDetailsQueryVariables = Exact<{
   roomId: Scalars['uuid'];
@@ -36809,39 +35816,16 @@ export type GetRoomParticipantDetailsQueryVariables = Exact<{
 }>;
 
 
-export type GetRoomParticipantDetailsQuery = (
-  { __typename?: 'query_root' }
-  & { room_Participant: Array<(
-    { __typename?: 'room_Participant' }
-    & RoomParticipantFragment
-  )> }
-);
+export type GetRoomParticipantDetailsQuery = { __typename?: 'query_root', room_Participant: Array<{ __typename?: 'room_Participant', id: any, vonageConnectionId?: Maybe<string>, chimeRegistrantId?: Maybe<string>, room: { __typename?: 'room_Room', id: any, conferenceId: any, publicVonageSessionId?: Maybe<string>, chimeMeeting?: Maybe<{ __typename?: 'room_ChimeMeeting', id: any, chimeMeetingId: string }> } }> };
 
-export type RoomParticipantFragment = (
-  { __typename?: 'room_Participant' }
-  & Pick<Room_Participant, 'id' | 'vonageConnectionId' | 'chimeRegistrantId'>
-  & { room: (
-    { __typename?: 'room_Room' }
-    & Pick<Room_Room, 'id' | 'conferenceId' | 'publicVonageSessionId'>
-    & { chimeMeeting?: Maybe<(
-      { __typename?: 'room_ChimeMeeting' }
-      & Pick<Room_ChimeMeeting, 'id' | 'chimeMeetingId'>
-    )> }
-  ) }
-);
+export type RoomParticipantFragment = { __typename?: 'room_Participant', id: any, vonageConnectionId?: Maybe<string>, chimeRegistrantId?: Maybe<string>, room: { __typename?: 'room_Room', id: any, conferenceId: any, publicVonageSessionId?: Maybe<string>, chimeMeeting?: Maybe<{ __typename?: 'room_ChimeMeeting', id: any, chimeMeetingId: string }> } };
 
 export type DeleteRoomParticipantsCreatedBeforeMutationVariables = Exact<{
   before: Scalars['timestamptz'];
 }>;
 
 
-export type DeleteRoomParticipantsCreatedBeforeMutation = (
-  { __typename?: 'mutation_root' }
-  & { delete_room_Participant?: Maybe<(
-    { __typename?: 'room_Participant_mutation_response' }
-    & Pick<Room_Participant_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type DeleteRoomParticipantsCreatedBeforeMutation = { __typename?: 'mutation_root', delete_room_Participant?: Maybe<{ __typename?: 'room_Participant_mutation_response', affected_rows: number }> };
 
 export type CreateTranscriptionJobMutationVariables = Exact<{
   awsTranscribeJobName: Scalars['String'];
@@ -36852,26 +35836,14 @@ export type CreateTranscriptionJobMutationVariables = Exact<{
 }>;
 
 
-export type CreateTranscriptionJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_video_TranscriptionJob_one?: Maybe<(
-    { __typename?: 'video_TranscriptionJob' }
-    & Pick<Video_TranscriptionJob, 'id'>
-  )> }
-);
+export type CreateTranscriptionJobMutation = { __typename?: 'mutation_root', insert_video_TranscriptionJob_one?: Maybe<{ __typename?: 'video_TranscriptionJob', id: any }> };
 
 export type GetTranscriptionJobQueryVariables = Exact<{
   awsTranscribeJobName: Scalars['String'];
 }>;
 
 
-export type GetTranscriptionJobQuery = (
-  { __typename?: 'query_root' }
-  & { video_TranscriptionJob: Array<(
-    { __typename?: 'video_TranscriptionJob' }
-    & Pick<Video_TranscriptionJob, 'videoS3Url' | 'elementId' | 'transcriptionS3Url' | 'languageCode' | 'id'>
-  )> }
-);
+export type GetTranscriptionJobQuery = { __typename?: 'query_root', video_TranscriptionJob: Array<{ __typename?: 'video_TranscriptionJob', videoS3Url: string, elementId: any, transcriptionS3Url: string, languageCode: string, id: any }> };
 
 export type CompleteVideoRenderJobMutationVariables = Exact<{
   videoRenderJobId: Scalars['uuid'];
@@ -36879,13 +35851,7 @@ export type CompleteVideoRenderJobMutationVariables = Exact<{
 }>;
 
 
-export type CompleteVideoRenderJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_video_VideoRenderJob_by_pk?: Maybe<(
-    { __typename?: 'video_VideoRenderJob' }
-    & Pick<Video_VideoRenderJob, 'id' | 'elementId'>
-  )> }
-);
+export type CompleteVideoRenderJobMutation = { __typename?: 'mutation_root', update_video_VideoRenderJob_by_pk?: Maybe<{ __typename?: 'video_VideoRenderJob', id: any, elementId: any }> };
 
 export type FailVideoRenderJobMutationVariables = Exact<{
   videoRenderJobId: Scalars['uuid'];
@@ -36893,13 +35859,7 @@ export type FailVideoRenderJobMutationVariables = Exact<{
 }>;
 
 
-export type FailVideoRenderJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_video_VideoRenderJob_by_pk?: Maybe<(
-    { __typename?: 'video_VideoRenderJob' }
-    & Pick<Video_VideoRenderJob, 'id' | 'conferencePrepareJobId'>
-  )> }
-);
+export type FailVideoRenderJobMutation = { __typename?: 'mutation_root', update_video_VideoRenderJob_by_pk?: Maybe<{ __typename?: 'video_VideoRenderJob', id: any, conferencePrepareJobId: any }> };
 
 export type ExpireVideoRenderJobMutationVariables = Exact<{
   videoRenderJobId: Scalars['uuid'];
@@ -36907,13 +35867,7 @@ export type ExpireVideoRenderJobMutationVariables = Exact<{
 }>;
 
 
-export type ExpireVideoRenderJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_video_VideoRenderJob_by_pk?: Maybe<(
-    { __typename?: 'video_VideoRenderJob' }
-    & Pick<Video_VideoRenderJob, 'id'>
-  )> }
-);
+export type ExpireVideoRenderJobMutation = { __typename?: 'mutation_root', update_video_VideoRenderJob_by_pk?: Maybe<{ __typename?: 'video_VideoRenderJob', id: any }> };
 
 export type UpdateVideoRenderJobMutationVariables = Exact<{
   videoRenderJobId: Scalars['uuid'];
@@ -36921,83 +35875,35 @@ export type UpdateVideoRenderJobMutationVariables = Exact<{
 }>;
 
 
-export type UpdateVideoRenderJobMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_video_VideoRenderJob_by_pk?: Maybe<(
-    { __typename?: 'video_VideoRenderJob' }
-    & Pick<Video_VideoRenderJob, 'id'>
-  )> }
-);
+export type UpdateVideoRenderJobMutation = { __typename?: 'mutation_root', update_video_VideoRenderJob_by_pk?: Maybe<{ __typename?: 'video_VideoRenderJob', id: any }> };
 
 export type CountUnfinishedVideoRenderJobsQueryVariables = Exact<{
   conferencePrepareJobId: Scalars['uuid'];
 }>;
 
 
-export type CountUnfinishedVideoRenderJobsQuery = (
-  { __typename?: 'query_root' }
-  & { video_VideoRenderJob_aggregate: (
-    { __typename?: 'video_VideoRenderJob_aggregate' }
-    & { aggregate?: Maybe<(
-      { __typename?: 'video_VideoRenderJob_aggregate_fields' }
-      & Pick<Video_VideoRenderJob_Aggregate_Fields, 'count'>
-    )> }
-  ) }
-);
+export type CountUnfinishedVideoRenderJobsQuery = { __typename?: 'query_root', video_VideoRenderJob_aggregate: { __typename?: 'video_VideoRenderJob_aggregate', aggregate?: Maybe<{ __typename?: 'video_VideoRenderJob_aggregate_fields', count: number }> } };
 
 export type GetBroadcastVideoRenderJobDetailsQueryVariables = Exact<{
   videoRenderJobId: Scalars['uuid'];
 }>;
 
 
-export type GetBroadcastVideoRenderJobDetailsQuery = (
-  { __typename?: 'query_root' }
-  & { video_VideoRenderJob_by_pk?: Maybe<(
-    { __typename?: 'video_VideoRenderJob' }
-    & Pick<Video_VideoRenderJob, 'id' | 'elementId' | 'jobStatusName'>
-    & { conferencePrepareJob: (
-      { __typename?: 'conference_PrepareJob' }
-      & Pick<Conference_PrepareJob, 'id' | 'jobStatusName'>
-    ) }
-  )> }
-);
+export type GetBroadcastVideoRenderJobDetailsQuery = { __typename?: 'query_root', video_VideoRenderJob_by_pk?: Maybe<{ __typename?: 'video_VideoRenderJob', id: any, elementId: any, jobStatusName: Video_JobStatus_Enum, conferencePrepareJob: { __typename?: 'conference_PrepareJob', id: any, jobStatusName: Video_JobStatus_Enum } }> };
 
 export type GetEventBroadcastDetailsQueryVariables = Exact<{
   eventId: Scalars['uuid'];
 }>;
 
 
-export type GetEventBroadcastDetailsQuery = (
-  { __typename?: 'query_root' }
-  & { schedule_Event_by_pk?: Maybe<(
-    { __typename?: 'schedule_Event' }
-    & Pick<Schedule_Event, 'id' | 'startTime' | 'durationSeconds' | 'endTime' | 'intendedRoomModeName'>
-    & { room: (
-      { __typename?: 'room_Room' }
-      & Pick<Room_Room, 'id'>
-      & { channelStack?: Maybe<(
-        { __typename?: 'video_ChannelStack' }
-        & Pick<Video_ChannelStack, 'rtmpAInputUri' | 'rtmpBInputUri' | 'id'>
-      )> }
-    ), eventVonageSession?: Maybe<(
-      { __typename?: 'video_EventVonageSession' }
-      & Pick<Video_EventVonageSession, 'sessionId' | 'id' | 'rtmpInputName'>
-    )> }
-  )> }
-);
+export type GetEventBroadcastDetailsQuery = { __typename?: 'query_root', schedule_Event_by_pk?: Maybe<{ __typename?: 'schedule_Event', id: any, startTime: any, durationSeconds: number, endTime?: Maybe<any>, intendedRoomModeName: Room_Mode_Enum, room: { __typename?: 'room_Room', id: any, channelStack?: Maybe<{ __typename?: 'video_ChannelStack', rtmpAInputUri: string, rtmpBInputUri?: Maybe<string>, id: any }> }, eventVonageSession?: Maybe<{ __typename?: 'video_EventVonageSession', sessionId: string, id: any, rtmpInputName: Video_RtmpInput_Enum }> }> };
 
 export type GetEventByVonageSessionIdQueryVariables = Exact<{
   sessionId: Scalars['String'];
 }>;
 
 
-export type GetEventByVonageSessionIdQuery = (
-  { __typename?: 'query_root' }
-  & { schedule_Event: Array<(
-    { __typename?: 'schedule_Event' }
-    & Pick<Schedule_Event, 'id' | 'conferenceId'>
-  )> }
-);
+export type GetEventByVonageSessionIdQuery = { __typename?: 'query_root', schedule_Event: Array<{ __typename?: 'schedule_Event', id: any, conferenceId: any }> };
 
 export type CreateEventParticipantStreamMutationVariables = Exact<{
   registrantId: Scalars['uuid'];
@@ -37009,13 +35915,7 @@ export type CreateEventParticipantStreamMutationVariables = Exact<{
 }>;
 
 
-export type CreateEventParticipantStreamMutation = (
-  { __typename?: 'mutation_root' }
-  & { insert_video_EventParticipantStream_one?: Maybe<(
-    { __typename?: 'video_EventParticipantStream' }
-    & Pick<Video_EventParticipantStream, 'id'>
-  )> }
-);
+export type CreateEventParticipantStreamMutation = { __typename?: 'mutation_root', insert_video_EventParticipantStream_one?: Maybe<{ __typename?: 'video_EventParticipantStream', id: any }> };
 
 export type RemoveEventParticipantStreamMutationVariables = Exact<{
   registrantId: Scalars['uuid'];
@@ -37026,13 +35926,7 @@ export type RemoveEventParticipantStreamMutationVariables = Exact<{
 }>;
 
 
-export type RemoveEventParticipantStreamMutation = (
-  { __typename?: 'mutation_root' }
-  & { delete_video_EventParticipantStream?: Maybe<(
-    { __typename?: 'video_EventParticipantStream_mutation_response' }
-    & Pick<Video_EventParticipantStream_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type RemoveEventParticipantStreamMutation = { __typename?: 'mutation_root', delete_video_EventParticipantStream?: Maybe<{ __typename?: 'video_EventParticipantStream_mutation_response', affected_rows: number }> };
 
 export type UpdateProfilePhotoMutationVariables = Exact<{
   registrantId: Scalars['uuid'];
@@ -37045,13 +35939,7 @@ export type UpdateProfilePhotoMutationVariables = Exact<{
 }>;
 
 
-export type UpdateProfilePhotoMutation = (
-  { __typename?: 'mutation_root' }
-  & { update_registrant_Profile?: Maybe<(
-    { __typename?: 'registrant_Profile_mutation_response' }
-    & Pick<Registrant_Profile_Mutation_Response, 'affected_rows'>
-  )> }
-);
+export type UpdateProfilePhotoMutation = { __typename?: 'mutation_root', update_registrant_Profile?: Maybe<{ __typename?: 'registrant_Profile_mutation_response', affected_rows: number }> };
 
 export const UploadYouTubeVideoJobDataFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"UploadYouTubeVideoJobData"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"job_queues_UploadYouTubeVideoJob"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"conferenceId"}},{"kind":"Field","name":{"kind":"Name","value":"jobStatusName"}},{"kind":"Field","name":{"kind":"Name","value":"retriesCount"}},{"kind":"Field","name":{"kind":"Name","value":"registrantGoogleAccount"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"tokenData"}},{"kind":"Field","name":{"kind":"Name","value":"googleAccountEmail"}}]}},{"kind":"Field","name":{"kind":"Name","value":"element"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"data"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"item"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"videoTitle"}},{"kind":"Field","name":{"kind":"Name","value":"videoDescription"}},{"kind":"Field","name":{"kind":"Name","value":"videoPrivacyStatus"}},{"kind":"Field","name":{"kind":"Name","value":"playlistId"}}]}}]} as unknown as DocumentNode<UploadYouTubeVideoJobDataFragment, unknown>;
 export const InvitationPartsFragmentDoc = {"kind":"Document","definitions":[{"kind":"FragmentDefinition","name":{"kind":"Name","value":"InvitationParts"},"typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"registrant_Invitation"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"registrantId"}},{"kind":"Field","name":{"kind":"Name","value":"registrant"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"displayName"}},{"kind":"Field","name":{"kind":"Name","value":"userId"}},{"kind":"Field","name":{"kind":"Name","value":"conference"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"slug"}}]}}]}},{"kind":"Field","name":{"kind":"Name","value":"confirmationCode"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"inviteCode"}},{"kind":"Field","name":{"kind":"Name","value":"invitedEmailAddress"}},{"kind":"Field","name":{"kind":"Name","value":"linkToUserId"}},{"kind":"Field","name":{"kind":"Name","value":"updatedAt"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"user"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"email"}}]}}]}}]} as unknown as DocumentNode<InvitationPartsFragment, unknown>;

--- a/services/actions/src/handlers/email.ts
+++ b/services/actions/src/handlers/email.ts
@@ -127,7 +127,7 @@ export async function insertEmails(
             return {
                 ...email,
                 htmlContents: htmlContents + "\n" + addedHTML,
-                plainTextContents: (email.plainTextContents ?? htmlToText(htmlContents)) + "\n" + addedText,
+                plainTextContents: htmlToText(htmlContents) + "\n" + addedText,
             };
         });
     if (emailsToInsert.length < emails.length) {

--- a/services/actions/src/server.ts
+++ b/services/actions/src/server.ts
@@ -3,12 +3,7 @@ import { json } from "body-parser";
 import cors from "cors";
 import express, { Request, Response } from "express";
 import { AuthenticatedRequest } from "./checkScopes";
-import {
-    invitationConfirmCurrentHandler,
-    invitationConfirmSendInitialEmailHandler,
-    invitationConfirmSendRepeatEmailHandler,
-    invitationConfirmWithCodeHandler,
-} from "./handlers/invitation";
+import { invitationConfirmCurrentHandler } from "./handlers/invitation";
 import { initialiseAwsClient } from "./lib/aws/awsClient";
 import { checkEventSecret } from "./middlewares/checkEventSecret";
 import { checkJwt } from "./middlewares/checkJwt";
@@ -111,60 +106,6 @@ app.post("/invitation/confirm/current", jsonParser, checkJwt, checkUserScopes, a
         return;
     }
 });
-
-app.post("/invitation/confirm/code", jsonParser, checkJwt, checkUserScopes, async (_req: Request, res: Response) => {
-    const req = _req as AuthenticatedRequest;
-    const params: invitationConfirmWithCodeArgs = req.body.input;
-    console.log("Invitation/confirm/code", params);
-    try {
-        const result = await invitationConfirmWithCodeHandler(params, req.userId);
-        return res.json(result);
-    } catch (e) {
-        console.error("Failure while processing /invitation/confirm/code", e);
-        res.status(500).json("Failure");
-        return;
-    }
-});
-
-app.post(
-    "/invitation/confirm/send/initial",
-    jsonParser,
-    checkJwt,
-    checkUserScopes,
-    async (_req: Request, res: Response) => {
-        const req = _req as AuthenticatedRequest;
-        const params: invitationConfirmSendInitialEmailArgs = req.body.input;
-        console.log("Invitation/confirm/send/initial", params);
-        try {
-            const result = await invitationConfirmSendInitialEmailHandler(params, req.userId);
-            return res.json(result);
-        } catch (e) {
-            console.error("Failure while processing /invitation/confirm/send/initial", e);
-            res.status(500).json("Failure");
-            return;
-        }
-    }
-);
-
-app.post(
-    "/invitation/confirm/send/repeat",
-    jsonParser,
-    checkJwt,
-    checkUserScopes,
-    async (_req: Request, res: Response) => {
-        const req = _req as AuthenticatedRequest;
-        const params: invitationConfirmSendRepeatEmailArgs = req.body.input;
-        console.log("Invitation/confirm/send/repeat", params);
-        try {
-            const result = await invitationConfirmSendRepeatEmailHandler(params, req.userId);
-            return res.json(result);
-        } catch (e) {
-            console.error("Failure while processing /invitation/confirm/send/repeat", e);
-            res.status(500).json("Failure");
-            return;
-        }
-    }
-);
 
 const portNumber = process.env.PORT ? parseInt(process.env.PORT, 10) : 4000;
 export const server = app.listen(portNumber, function () {


### PR DESCRIPTION
## What's fixed

* Fix plaintext version of emails where template variables weren't substituted correctly
* Remove dead invitation code that we haven't used since February

## Upgrading

Instructions for other developers on how to upgrade their environment after
pulling this new code. Please tick (i.e. put an 'x' in) the boxes for the
actions that are necessary.

- [x] Run GraphQL Codegen in the frontend/actions service
- [ ] Re-install NPM packages in [insert name of folder]
- [x] Apply Hasura migrations
- [x] Apply Hasura metadata
- [ ] Update Auth0 rules
- [ ] Update environment variables
- [ ] Re-deploy AWS CDK [and update AWS environment variables]

## Deployment

Instructions for how to deploy these changes to production. Please tick (i.e.
put an 'x' in) the boxes for the actions that are necessary.

- [x] Apply migrations to Hasura
- [x] Apply metadata to Hasura
- [ ] Reload enum table/values in Hasura for [table names]
- [x] Re-deploy frontend
- [x] Re-deploy actions service
- [ ] Re-deploy playout service
- [ ] Re-deploy real-time service
- [ ] Flush real-time service state (Redis/RabbitMQ)
- [ ] Update environment variables for [name of component]

Any other steps necessary to re-deploy? No.
