### PR TITLE
🗃 Improvement/backstage preview

### DIFF
--- a/frontend/src/aspects/Conference/Attend/Room/Room.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Room.tsx
@@ -534,6 +534,7 @@ function RoomInner({
                 onEventSelected={setBackstageSelectedEventId}
                 roomChatId={roomDetails.chatId}
                 onLeave={onLeaveBackstage}
+                hlsUri={hlsUri ?? undefined}
             />
         ),
         [
@@ -545,6 +546,7 @@ function RoomInner({
             nextRoomEvent?.id,
             backstageSelectedEventId,
             onLeaveBackstage,
+            hlsUri,
         ]
     );
 

--- a/frontend/src/aspects/Conference/Attend/Room/Stream/Backstage.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Stream/Backstage.tsx
@@ -25,12 +25,14 @@ export default function Backstage({
     setSelectedEventId,
     roomChatId,
     onLeave,
+    hlsUri,
 }: {
     roomChatId: string | undefined | null;
     event: Room_EventSummaryFragment;
     selectedEventId: string | null;
     setSelectedEventId: (value: string | null) => void;
     onLeave?: () => void;
+    hlsUri: string | undefined;
 }): JSX.Element {
     const [gray100, gray900] = useToken("colors", ["gray.100", "gray.900"]);
     const greyBorderColour = useColorModeValue(gray900, gray100);
@@ -90,8 +92,8 @@ export default function Backstage({
     );
 
     const vonageBackstage = useMemo(
-        () => <VonageBackstage eventId={event.id} onLeave={onLeave} />,
-        [event.id, onLeave]
+        () => <VonageBackstage eventId={event.id} onLeave={onLeave} hlsUri={hlsUri} />,
+        [event.id, onLeave, hlsUri]
     );
     const area = useMemo(
         () =>

--- a/frontend/src/aspects/Conference/Attend/Room/Stream/Backstage.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Stream/Backstage.tsx
@@ -80,10 +80,10 @@ export default function Backstage({
                 >
                     <Text fontSize="lg" whiteSpace="normal">
                         {isSelected
-                            ? "Close this backstage"
+                            ? "Exit this backstage"
                             : selectedEventId
                             ? "Switch to this backstage"
-                            : "Open this backstage"}
+                            : "Show this backstage"}
                     </Text>
                 </Button>
             </HStack>

--- a/frontend/src/aspects/Conference/Attend/Room/Stream/Backstages.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Stream/Backstages.tsx
@@ -38,6 +38,7 @@ export function Backstages({
     onEventSelected,
     roomChatId,
     onLeave,
+    hlsUri,
 }: {
     showBackstage: boolean;
     roomName: string;
@@ -49,6 +50,7 @@ export function Backstages({
     roomChatId: string | null | undefined;
     selectedEventId: string | null;
     onLeave?: () => void;
+    hlsUri: string | undefined;
 }): JSX.Element {
     const [gray100, gray900] = useToken("colors", ["gray.100", "gray.900"]);
     const backgroundColour = useColorModeValue(gray100, gray900);
@@ -94,6 +96,7 @@ export function Backstages({
                             setSelectedEventId={onEventSelected}
                             roomChatId={roomChatId}
                             onLeave={onLeave}
+                            hlsUri={hlsUri}
                         />
                     </Box>
                 ))}
@@ -105,7 +108,7 @@ export function Backstages({
                 ) : undefined}
             </Box>
         );
-    }, [activeEvents, roomChatId, selectedEventId, onEventSelected, onLeave]);
+    }, [activeEvents, roomChatId, selectedEventId, onEventSelected, onLeave, hlsUri]);
 
     const sharedRoomContext = useSharedRoomContext();
 

--- a/frontend/src/aspects/Conference/Attend/Room/Stream/Controls/BackstageControls.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Stream/Controls/BackstageControls.tsx
@@ -24,8 +24,8 @@ import { useRealTime } from "../../../../../Generic/useRealTime";
 import useQueryErrorToast from "../../../../../GQL/useQueryErrorToast";
 import { FAIcon } from "../../../../../Icons/FAIcon";
 import { useVonageGlobalState } from "../../Vonage/VonageGlobalStateProvider";
-import { LayoutControls } from "./LayoutControls";
 import { ImmediateSwitch } from "./ImmediateSwitch";
+import { LayoutControls } from "./LayoutControls";
 import { LiveIndicator } from "./LiveIndicator";
 
 gql`
@@ -49,7 +49,13 @@ gql`
     }
 `;
 
-export function BackstageControls({ event }: { event: RoomEventDetailsFragment }): JSX.Element {
+export function BackstageControls({
+    event,
+    hlsUri,
+}: {
+    event: RoomEventDetailsFragment;
+    hlsUri: string | undefined;
+}): JSX.Element {
     const startTime = useMemo(() => Date.parse(event.startTime), [event.startTime]);
     const endTime = useMemo(() => Date.parse(event.endTime), [event.endTime]);
     const realNow = useRealTime(1000);
@@ -152,6 +158,7 @@ export function BackstageControls({ event }: { event: RoomEventDetailsFragment }
                 now={now}
                 eventId={event.id}
                 isConnected={isConnected}
+                hlsUri={hlsUri}
             />
             <HStack flexWrap="wrap" w="100%" justifyContent="center" alignItems="flex-end" my={2}>
                 {immediateSwitchControls}

--- a/frontend/src/aspects/Conference/Attend/Room/Stream/Controls/BackstageControls.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Stream/Controls/BackstageControls.tsx
@@ -87,66 +87,53 @@ export function BackstageControls({
     }, [vonageGlobalState]);
 
     const broadcastPopover = useMemo(
-        () =>
-            isConnected ? (
-                <Popover placement="auto-end" isLazy>
-                    <PopoverTrigger>
-                        <VStack>
-                            <Button
-                                aria-label="Advanced broadcast controls"
-                                title="Advanced broadcast controls"
-                                textAlign="center"
-                            >
-                                <FAIcon icon="cogs" iconStyle="s" mr={2} />
-                                <Text>Stream layout</Text>
-                            </Button>
-                        </VStack>
-                    </PopoverTrigger>
-                    <Portal>
-                        <Box zIndex="500" position="relative">
-                            <PopoverContent>
-                                <PopoverArrow />
-                                <PopoverCloseButton />
-                                <PopoverHeader>Broadcast controls</PopoverHeader>
-                                <PopoverBody>
-                                    <Text fontSize="sm" mb={2}>
-                                        Here you can control how the video streams from the backstage are laid out in
-                                        the broadcast video.
-                                    </Text>
-                                    {streamsError ? (
-                                        <>Error loading streams.</>
-                                    ) : streamsLoading ? (
-                                        <Spinner />
-                                    ) : undefined}
-                                    <LayoutControls
-                                        live={live}
-                                        streams={streamsData?.video_EventParticipantStream ?? null}
-                                        eventVonageSessionId={event.eventVonageSession?.id ?? null}
-                                    />
-                                </PopoverBody>
-                            </PopoverContent>
-                        </Box>
-                    </Portal>
-                </Popover>
-            ) : undefined,
-        [
-            event.eventVonageSession?.id,
-            live,
-            streamsData?.video_EventParticipantStream,
-            streamsError,
-            streamsLoading,
-            isConnected,
-        ]
+        () => (
+            <Popover placement="auto-end" isLazy>
+                <PopoverTrigger>
+                    <VStack>
+                        <Button
+                            aria-label="Advanced broadcast controls"
+                            title="Advanced broadcast controls"
+                            textAlign="center"
+                        >
+                            <FAIcon icon="cogs" iconStyle="s" mr={2} />
+                            <Text>Stream layout</Text>
+                        </Button>
+                    </VStack>
+                </PopoverTrigger>
+                <Portal>
+                    <Box zIndex="500" position="relative">
+                        <PopoverContent>
+                            <PopoverArrow />
+                            <PopoverCloseButton />
+                            <PopoverHeader>Broadcast controls</PopoverHeader>
+                            <PopoverBody>
+                                <Text fontSize="sm" mb={2}>
+                                    Here you can control how the video streams from the backstage are laid out in the
+                                    broadcast video.
+                                </Text>
+                                {streamsError ? <>Error loading streams.</> : streamsLoading ? <Spinner /> : undefined}
+                                <LayoutControls
+                                    live={live}
+                                    streams={streamsData?.video_EventParticipantStream ?? null}
+                                    eventVonageSessionId={event.eventVonageSession?.id ?? null}
+                                />
+                            </PopoverBody>
+                        </PopoverContent>
+                    </Box>
+                </Portal>
+            </Popover>
+        ),
+        [event.eventVonageSession?.id, live, streamsData?.video_EventParticipantStream, streamsError, streamsLoading]
     );
 
     const immediateSwitchControls = useMemo(
-        () =>
-            isConnected ? (
-                <Box maxW="30ch">
-                    <ImmediateSwitch live={live} secondsUntilOffAir={secondsUntilOffAir} eventId={event.id} />
-                </Box>
-            ) : undefined,
-        [event.id, live, secondsUntilOffAir, isConnected]
+        () => (
+            <Box maxW="30ch">
+                <ImmediateSwitch live={live} secondsUntilOffAir={secondsUntilOffAir} eventId={event.id} />
+            </Box>
+        ),
+        [event.id, live, secondsUntilOffAir]
     );
 
     return (

--- a/frontend/src/aspects/Conference/Attend/Room/Stream/Controls/ImmediateSwitch.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Stream/Controls/ImmediateSwitch.tsx
@@ -28,6 +28,7 @@ import { validate } from "uuid";
 import {
     useImmediateSwitch_CreateMutation,
     useImmediateSwitch_GetElementsQuery,
+    useLiveIndicator_GetLatestQuery,
 } from "../../../../../../generated/graphql";
 import { useRealTime } from "../../../../../Generic/useRealTime";
 import FAIcon from "../../../../../Icons/FAIcon";
@@ -86,6 +87,9 @@ export function ImmediateSwitch({
     });
 
     const [createImmediateSwitch] = useImmediateSwitch_CreateMutation();
+    const liveIndicatorLatest = useLiveIndicator_GetLatestQuery({
+        skip: true,
+    });
 
     const now = useRealTime(1000);
     const [lastSwitched, setLastSwitched] = useState<number>(0);
@@ -143,6 +147,9 @@ export function ImmediateSwitch({
                                 eventId,
                                 conferenceId: conference.id,
                             },
+                        });
+                        await liveIndicatorLatest.refetch({
+                            eventId,
                         });
                     } catch (err: any) {
                         toast({
@@ -211,7 +218,7 @@ export function ImmediateSwitch({
             }
             setLastSwitched(now);
         },
-        [conference.id, createImmediateSwitch, eventId, now, toast]
+        [conference.id, createImmediateSwitch, eventId, liveIndicatorLatest, now, toast]
     );
 
     const cancelRef = useRef<HTMLButtonElement>(null);

--- a/frontend/src/aspects/Conference/Attend/Room/Stream/Controls/LiveIndicator.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Stream/Controls/LiveIndicator.tsx
@@ -195,9 +195,17 @@ export function LiveIndicator({
             case "video_unknown_duration":
                 return (
                     <>
-                        <FAIcon icon="play" iconStyle="s" fontSize="lg" />
-                        <Text>Video or live</Text>
-                        <Text fontSize="xs">Unable to load video duration; the backstage may be live again.</Text>
+                        <VStack>
+                            <HStack>
+                                <FAIcon icon="play" iconStyle="s" fontSize="lg" />
+                                <Text>Video or live</Text>
+                            </HStack>
+                            <Text fontSize="xs" textTransform="none">
+                                Video duration unknown (not prepared for broadcast);
+                                <br />
+                                the backstage may be live again.
+                            </Text>
+                        </VStack>
                     </>
                 );
             case "video_ending":
@@ -243,17 +251,7 @@ export function LiveIndicator({
     const liveIndicactor = useMemo(
         () =>
             live ? (
-                <HStack
-                    alignItems="stretch"
-                    justifyContent="flex-start"
-                    mx="auto"
-                    flexWrap="wrap"
-                    pos="sticky"
-                    top={0}
-                    bgColor={bgColor}
-                    zIndex={10000}
-                    overflow="visible"
-                >
+                <>
                     <Badge
                         fontSize={isConnected ? "lg" : "md"}
                         colorScheme="red"
@@ -265,23 +263,13 @@ export function LiveIndicator({
                     >
                         <HStack>{whatIsLiveText}</HStack>
                     </Badge>
-                    <Stat fontSize="md" ml="auto" flexGrow={1} textAlign="center">
+                    <Stat fontSize="md" ml="auto" flexGrow={1} textAlign="center" p="2px">
                         <StatLabel>Time until end</StatLabel>
                         <StatNumber>{formatRemainingTime(secondsUntilOffAir)}</StatNumber>
                     </Stat>
-                </HStack>
+                </>
             ) : (
-                <HStack
-                    alignItems="stretch"
-                    justifyContent="flex-start"
-                    mx="auto"
-                    flexWrap="wrap"
-                    pos="sticky"
-                    top={0}
-                    bgColor={bgColor}
-                    zIndex={10000}
-                    overflow="visible"
-                >
+                <>
                     {secondsUntilLive > 0 ? (
                         <>
                             <Badge
@@ -309,7 +297,6 @@ export function LiveIndicator({
                                     flexGrow={1}
                                     textAlign="center"
                                     color={secondsUntilLive < 10 ? "white" : undefined}
-                                    p={2}
                                     backgroundColor={
                                         secondsUntilLive < 10
                                             ? secondsUntilLive % 2 >= 1
@@ -317,6 +304,7 @@ export function LiveIndicator({
                                                 : "black"
                                             : undefined
                                     }
+                                    p="2px"
                                 >
                                     <StatLabel>Time until start</StatLabel>
                                     <StatNumber>{formatRemainingTime(secondsUntilLive)}</StatNumber>
@@ -335,9 +323,9 @@ export function LiveIndicator({
                             <Text>Backstage is off air</Text>
                         </Badge>
                     )}
-                </HStack>
+                </>
             ),
-        [bgColor, isConnected, live, onOpen, secondsUntilLive, secondsUntilOffAir, whatIsLiveText]
+        [isConnected, live, onOpen, secondsUntilLive, secondsUntilOffAir, whatIsLiveText]
     );
     const isLiveOnAir = live && currentInput !== "video" && currentInput !== "filler";
     const streamPreview = useMemo(
@@ -346,10 +334,34 @@ export function LiveIndicator({
     );
 
     return (
-        <>
+        <HStack
+            alignItems="flex-start"
+            justifyContent="flex-start"
+            mx="auto"
+            flexWrap="wrap"
+            pos="sticky"
+            top={0}
+            zIndex={10000}
+            overflow="visible"
+            gridRowGap={2}
+        >
             {streamPreview}
-            {liveIndicactor}
-            {infoModal}
-        </>
+            <HStack
+                p={1}
+                bgColor={bgColor}
+                alignItems="flex-start"
+                justifyContent="flex-start"
+                mx="auto"
+                flexWrap="wrap"
+                pos="sticky"
+                top={0}
+                zIndex={10000}
+                overflow="visible"
+                gridRowGap={2}
+            >
+                {liveIndicactor}
+                {infoModal}
+            </HStack>
+        </HStack>
     );
 }

--- a/frontend/src/aspects/Conference/Attend/Room/Stream/Controls/StreamPreview.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Stream/Controls/StreamPreview.tsx
@@ -1,0 +1,46 @@
+import { Box, Text, VStack } from "@chakra-ui/react";
+import React from "react";
+import { HlsPlayer } from "../../Video/HlsPlayer";
+import { VideoAspectWrapper } from "../../Video/VideoAspectWrapper";
+
+export default function StreamPreview({
+    hlsUri,
+    isLive,
+    isLiveOnAir,
+}: {
+    hlsUri: string | undefined;
+    isLive: boolean;
+    isLiveOnAir: boolean;
+}): JSX.Element {
+    return hlsUri ? (
+        <VStack spacing={1} maxW="400px" maxH="240px" w="10vw" border="1px solid black">
+            <Text pos="relative" whiteSpace="normal" flex="0 1 100%">
+                Stream preview
+            </Text>
+            <Text pos="relative" whiteSpace="normal" fontSize="xs" flex="0 1 100%">
+                Please remember the preview plays with a lag.
+            </Text>
+            <Box pos="relative" flex="0 1 100%">
+                <VideoAspectWrapper>
+                    {(onAspectRatioChange) => (
+                        <HlsPlayer
+                            canPlay={isLive}
+                            hlsUri={hlsUri}
+                            onAspectRatioChange={onAspectRatioChange}
+                            expectLivestream={isLive}
+                            forceMute={isLiveOnAir}
+                            initialMute={true}
+                        />
+                    )}
+                </VideoAspectWrapper>
+            </Box>
+            <Text pos="relative" whiteSpace="normal" fontSize="xs" flex="0 1 100%">
+                To avoid echoes, mute the preview while you are live on air.
+            </Text>
+        </VStack>
+    ) : (
+        <Text pos="relative" maxW="400px" maxH="240px" w="10vw" whiteSpace="normal">
+            Stream preview not currently available
+        </Text>
+    );
+}

--- a/frontend/src/aspects/Conference/Attend/Room/Stream/VonageBackstage.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Stream/VonageBackstage.tsx
@@ -45,12 +45,14 @@ export function VonageBackstage({
     isRaiseHandWaiting,
     completeJoinRef,
     onLeave,
+    hlsUri,
 }: {
     eventId: string;
     isRaiseHandPreJoin?: boolean;
     isRaiseHandWaiting?: boolean;
     completeJoinRef?: React.MutableRefObject<() => Promise<void>>;
     onLeave?: () => void;
+    hlsUri: string | undefined;
 }): JSX.Element {
     const [getEventVonageToken] = useGetEventVonageTokenMutation({
         variables: {
@@ -79,7 +81,7 @@ export function VonageBackstage({
         <ApolloQueryWrapper queryResult={result} getter={(data) => data.schedule_Event_by_pk}>
             {(event: RoomEventDetailsFragment) => (
                 <VStack justifyContent="stretch" w="100%">
-                    {!isRaiseHandPreJoin ? <BackstageControls event={event} /> : undefined}
+                    {!isRaiseHandPreJoin ? <BackstageControls event={event} hlsUri={hlsUri} /> : undefined}
                     <Box w="100%">
                         {event.eventVonageSession && sharedRoomContext ? (
                             <portals.OutPortal

--- a/frontend/src/aspects/Conference/Attend/Room/Video/HlsPlayer.tsx
+++ b/frontend/src/aspects/Conference/Attend/Room/Video/HlsPlayer.tsx
@@ -118,12 +118,25 @@ export function HlsPlayerInner({
         }
     }, [canPlay, intendPlayStream]);
 
+    // This is deliberately designed so that force mute operates
+    // as a one-off mute (an effect) rather than a global force
+    // which the user would be unable to override.
+    //
+    // This is so that force mute will trigger a stream preview
+    // to be muted when the backstage goes live. But the preview
+    // can be unmuted by the user if needed/desired.
     useEffect(() => {
         if (!videoRef.current) {
             return;
         }
-        videoRef.current.muted = forceMute || intendMuted;
-    }, [forceMute, intendMuted]);
+        videoRef.current.muted = intendMuted;
+    }, [intendMuted]);
+    useEffect(() => {
+        if (!videoRef.current) {
+            return;
+        }
+        videoRef.current.muted = forceMute || videoRef.current.muted;
+    }, [forceMute]);
 
     useEffect(() => {
         if (!videoRef.current || videoRef.current.volume === volume) {

--- a/frontend/src/aspects/Menu/V1/RightSidebarPanels/RaiseHandPanel.tsx
+++ b/frontend/src/aspects/Menu/V1/RightSidebarPanels/RaiseHandPanel.tsx
@@ -164,6 +164,7 @@ export function RaiseHandPanel(): JSX.Element {
                     isRaiseHandPreJoin={true}
                     isRaiseHandWaiting={raisedHandUserIds.includes(currentUser.id)}
                     completeJoinRef={completeJoinRef}
+                    hlsUri={undefined}
                 />
                 <Text fontWeight="bold" pt={4}>
                     Raised hands

--- a/frontend/src/aspects/Menu/V2/RightSidebar/Panels/RaiseHandPanel.tsx
+++ b/frontend/src/aspects/Menu/V2/RightSidebar/Panels/RaiseHandPanel.tsx
@@ -164,6 +164,7 @@ export function RaiseHandPanel(): JSX.Element {
                     isRaiseHandPreJoin={true}
                     isRaiseHandWaiting={raisedHandUserIds.includes(currentUser.id)}
                     completeJoinRef={completeJoinRef}
+                    hlsUri={undefined}
                 />
                 <Text fontWeight="bold" pt={4}>
                     Raised hands

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -7831,6 +7831,8 @@ export enum Conference_ConfigurationKey_Enum {
   ClowdrAppVersion = 'CLOWDR_APP_VERSION',
   EmailTemplateSubmissionRequest = 'EMAIL_TEMPLATE_SUBMISSION_REQUEST',
   EmailTemplateSubtitlesGenerated = 'EMAIL_TEMPLATE_SUBTITLES_GENERATED',
+  /** Boolean. Whether to enable the backstage stream preview or not. */
+  EnableBackstageStreamPreview = 'ENABLE_BACKSTAGE_STREAM_PREVIEW',
   /** List of S3 URLs. */
   FillerVideos = 'FILLER_VIDEOS',
   /** A string representing the full frontend host URL for the conference. If not provided, this defaults to the system configuration. */
@@ -9880,6 +9882,7 @@ export type Content_Element_Order_By = {
   readonly isHidden?: Maybe<Order_By>;
   readonly item?: Maybe<Content_Item_Order_By>;
   readonly itemId?: Maybe<Order_By>;
+  readonly itemTitle?: Maybe<Order_By>;
   readonly layoutData?: Maybe<Order_By>;
   readonly name?: Maybe<Order_By>;
   readonly originatingData?: Maybe<Conference_OriginatingData_Order_By>;
@@ -23256,6 +23259,7 @@ export type Registrant_Invitation_Order_By = {
   readonly confirmationCode?: Maybe<Order_By>;
   readonly createdAt?: Maybe<Order_By>;
   readonly emails_aggregate?: Maybe<Email_Aggregate_Order_By>;
+  readonly hash?: Maybe<Order_By>;
   readonly id?: Maybe<Order_By>;
   readonly inviteCode?: Maybe<Order_By>;
   readonly invitedEmailAddress?: Maybe<Order_By>;
@@ -24126,6 +24130,7 @@ export type Registrant_Registrant_Order_By = {
   readonly groupRegistrants_aggregate?: Maybe<Permissions_GroupRegistrant_Aggregate_Order_By>;
   readonly id?: Maybe<Order_By>;
   readonly invitation?: Maybe<Registrant_Invitation_Order_By>;
+  readonly inviteSent?: Maybe<Order_By>;
   readonly profile?: Maybe<Registrant_Profile_Order_By>;
   readonly programPeople_aggregate?: Maybe<Collection_ProgramPerson_Aggregate_Order_By>;
   readonly roomParticipants_aggregate?: Maybe<Room_Participant_Aggregate_Order_By>;
@@ -26073,6 +26078,7 @@ export type Room_Room_Order_By = {
   readonly currentModeName?: Maybe<Order_By>;
   readonly events_aggregate?: Maybe<Schedule_Event_Aggregate_Order_By>;
   readonly id?: Maybe<Order_By>;
+  readonly isProgramRoom?: Maybe<Order_By>;
   readonly livestreamDuration?: Maybe<Room_LivestreamDurations_Order_By>;
   readonly managementMode?: Maybe<Room_ManagementMode_Order_By>;
   readonly managementModeName?: Maybe<Order_By>;
@@ -35415,69 +35421,6 @@ export type Registrant_RegistrantCreateRoomMutationVariables = Exact<{
 
 export type Registrant_RegistrantCreateRoomMutation = { readonly __typename?: 'mutation_root', readonly insert_room_Room_one?: Maybe<{ readonly __typename?: 'room_Room', readonly id: any, readonly name: string, readonly priority: number, readonly managementModeName: Room_ManagementMode_Enum, readonly originatingEventId?: Maybe<any>, readonly originatingItem?: Maybe<{ readonly __typename?: 'content_Item', readonly id: any, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly roleName: string, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly registrantId?: Maybe<any> } }> }> }> };
 
-export type UpdateEventVonageSessionLayoutMutationVariables = Exact<{
-  eventVonageSessionId: Scalars['uuid'];
-  layoutData: Scalars['jsonb'];
-}>;
-
-
-export type UpdateEventVonageSessionLayoutMutation = { readonly __typename?: 'mutation_root', readonly update_video_EventVonageSession_by_pk?: Maybe<{ readonly __typename?: 'video_EventVonageSession', readonly id: any }> };
-
-export type GetEventParticipantStreamsSubscriptionVariables = Exact<{
-  eventId: Scalars['uuid'];
-}>;
-
-
-export type GetEventParticipantStreamsSubscription = { readonly __typename?: 'subscription_root', readonly video_EventParticipantStream: ReadonlyArray<{ readonly __typename?: 'video_EventParticipantStream', readonly id: any, readonly conferenceId: any, readonly eventId: any, readonly vonageStreamType: string, readonly vonageStreamId: string, readonly registrantId: any, readonly registrant: { readonly __typename?: 'registrant_Registrant', readonly id: any, readonly displayName: string } }> };
-
-export type EventParticipantStreamDetailsFragment = { readonly __typename?: 'video_EventParticipantStream', readonly id: any, readonly conferenceId: any, readonly eventId: any, readonly vonageStreamType: string, readonly vonageStreamId: string, readonly registrantId: any, readonly registrant: { readonly __typename?: 'registrant_Registrant', readonly id: any, readonly displayName: string } };
-
-export type GetEventVonageTokenMutationVariables = Exact<{
-  eventId: Scalars['uuid'];
-}>;
-
-
-export type GetEventVonageTokenMutation = { readonly __typename?: 'mutation_root', readonly joinEventVonageSession?: Maybe<{ readonly __typename?: 'JoinEventVonageSessionOutput', readonly accessToken?: Maybe<string> }> };
-
-export type GetEventDetailsQueryVariables = Exact<{
-  eventId: Scalars['uuid'];
-}>;
-
-
-export type GetEventDetailsQuery = { readonly __typename?: 'query_root', readonly schedule_Event_by_pk?: Maybe<{ readonly __typename?: 'schedule_Event', readonly id: any, readonly conferenceId: any, readonly startTime: any, readonly name: string, readonly durationSeconds: number, readonly endTime?: Maybe<any>, readonly intendedRoomModeName: Room_Mode_Enum, readonly eventVonageSession?: Maybe<{ readonly __typename?: 'video_EventVonageSession', readonly id: any, readonly sessionId: string }> }> };
-
-export type RoomEventDetailsFragment = { readonly __typename?: 'schedule_Event', readonly id: any, readonly conferenceId: any, readonly startTime: any, readonly name: string, readonly durationSeconds: number, readonly endTime?: Maybe<any>, readonly intendedRoomModeName: Room_Mode_Enum, readonly eventVonageSession?: Maybe<{ readonly __typename?: 'video_EventVonageSession', readonly id: any, readonly sessionId: string }> };
-
-export type ImmediateSwitch_GetElementsQueryVariables = Exact<{
-  eventId: Scalars['uuid'];
-}>;
-
-
-export type ImmediateSwitch_GetElementsQuery = { readonly __typename?: 'query_root', readonly schedule_Event_by_pk?: Maybe<{ readonly __typename?: 'schedule_Event', readonly id: any, readonly item?: Maybe<{ readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly name: string }> }>, readonly exhibition?: Maybe<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly items: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly item: { readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly name: string }> } }> }> }> };
-
-export type ImmediateSwitch_CreateMutationVariables = Exact<{
-  data: Scalars['jsonb'];
-  eventId: Scalars['uuid'];
-  conferenceId: Scalars['uuid'];
-}>;
-
-
-export type ImmediateSwitch_CreateMutation = { readonly __typename?: 'mutation_root', readonly insert_video_ImmediateSwitch_one?: Maybe<{ readonly __typename?: 'video_ImmediateSwitch', readonly id: any }> };
-
-export type LiveIndicator_GetLatestQueryVariables = Exact<{
-  eventId: Scalars['uuid'];
-}>;
-
-
-export type LiveIndicator_GetLatestQuery = { readonly __typename?: 'query_root', readonly video_ImmediateSwitch: ReadonlyArray<{ readonly __typename?: 'video_ImmediateSwitch', readonly id: any, readonly data: any, readonly executedAt?: Maybe<any> }> };
-
-export type LiveIndicator_GetElementQueryVariables = Exact<{
-  elementId: Scalars['uuid'];
-}>;
-
-
-export type LiveIndicator_GetElementQuery = { readonly __typename?: 'query_root', readonly content_Element_by_pk?: Maybe<{ readonly __typename?: 'content_Element', readonly id: any, readonly data: any }> };
-
 export type Room_GetEventsQueryVariables = Exact<{
   roomId: Scalars['uuid'];
   now: Scalars['timestamptz'];
@@ -35521,6 +35464,13 @@ export type RoomPage_GetRoomChannelStackQuery = { readonly __typename?: 'query_r
 
 export type RoomPage_RoomChannelStackFragment = { readonly __typename?: 'video_ChannelStack', readonly cloudFrontDomain: string, readonly endpointUri: string, readonly id: any };
 
+export type GetEventVonageTokenMutationVariables = Exact<{
+  eventId: Scalars['uuid'];
+}>;
+
+
+export type GetEventVonageTokenMutation = { readonly __typename?: 'mutation_root', readonly joinEventVonageSession?: Maybe<{ readonly __typename?: 'JoinEventVonageSessionOutput', readonly accessToken?: Maybe<string> }> };
+
 export type GetEventVonageDetailsQueryVariables = Exact<{
   eventId: Scalars['uuid'];
 }>;
@@ -35538,6 +35488,69 @@ export type RoomSponsorContent_GetElementsQuery = { readonly __typename?: 'query
 export type RoomSponsorContent_ItemDataFragment = { readonly __typename?: 'content_Item', readonly id: any, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly name: string, readonly isHidden: boolean, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly layoutData?: Maybe<any> }> };
 
 export type RoomSponsorContent_ElementDataFragment = { readonly __typename?: 'content_Element', readonly id: any, readonly name: string, readonly isHidden: boolean, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly layoutData?: Maybe<any> };
+
+export type GetEventParticipantStreamsSubscriptionVariables = Exact<{
+  eventId: Scalars['uuid'];
+}>;
+
+
+export type GetEventParticipantStreamsSubscription = { readonly __typename?: 'subscription_root', readonly video_EventParticipantStream: ReadonlyArray<{ readonly __typename?: 'video_EventParticipantStream', readonly id: any, readonly conferenceId: any, readonly eventId: any, readonly vonageStreamType: string, readonly vonageStreamId: string, readonly registrantId: any, readonly registrant: { readonly __typename?: 'registrant_Registrant', readonly id: any, readonly displayName: string } }> };
+
+export type EventParticipantStreamDetailsFragment = { readonly __typename?: 'video_EventParticipantStream', readonly id: any, readonly conferenceId: any, readonly eventId: any, readonly vonageStreamType: string, readonly vonageStreamId: string, readonly registrantId: any, readonly registrant: { readonly __typename?: 'registrant_Registrant', readonly id: any, readonly displayName: string } };
+
+export type ImmediateSwitch_GetElementsQueryVariables = Exact<{
+  eventId: Scalars['uuid'];
+}>;
+
+
+export type ImmediateSwitch_GetElementsQuery = { readonly __typename?: 'query_root', readonly schedule_Event_by_pk?: Maybe<{ readonly __typename?: 'schedule_Event', readonly id: any, readonly item?: Maybe<{ readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly name: string }> }>, readonly exhibition?: Maybe<{ readonly __typename?: 'collection_Exhibition', readonly id: any, readonly items: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly item: { readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly name: string }> } }> }> }> };
+
+export type ImmediateSwitch_CreateMutationVariables = Exact<{
+  data: Scalars['jsonb'];
+  eventId: Scalars['uuid'];
+  conferenceId: Scalars['uuid'];
+}>;
+
+
+export type ImmediateSwitch_CreateMutation = { readonly __typename?: 'mutation_root', readonly insert_video_ImmediateSwitch_one?: Maybe<{ readonly __typename?: 'video_ImmediateSwitch', readonly id: any }> };
+
+export type UpdateEventVonageSessionLayoutMutationVariables = Exact<{
+  eventVonageSessionId: Scalars['uuid'];
+  layoutData: Scalars['jsonb'];
+}>;
+
+
+export type UpdateEventVonageSessionLayoutMutation = { readonly __typename?: 'mutation_root', readonly update_video_EventVonageSession_by_pk?: Maybe<{ readonly __typename?: 'video_EventVonageSession', readonly id: any }> };
+
+export type LiveIndicator_GetLatestQueryVariables = Exact<{
+  eventId: Scalars['uuid'];
+}>;
+
+
+export type LiveIndicator_GetLatestQuery = { readonly __typename?: 'query_root', readonly video_ImmediateSwitch: ReadonlyArray<{ readonly __typename?: 'video_ImmediateSwitch', readonly id: any, readonly data: any, readonly executedAt?: Maybe<any> }> };
+
+export type LiveIndicator_GetElementQueryVariables = Exact<{
+  elementId: Scalars['uuid'];
+}>;
+
+
+export type LiveIndicator_GetElementQuery = { readonly __typename?: 'query_root', readonly content_Element_by_pk?: Maybe<{ readonly __typename?: 'content_Element', readonly id: any, readonly data: any }> };
+
+export type EnableBackstageStreamPreviewQueryVariables = Exact<{
+  conferenceId: Scalars['uuid'];
+}>;
+
+
+export type EnableBackstageStreamPreviewQuery = { readonly __typename?: 'query_root', readonly conference_Configuration_by_pk?: Maybe<{ readonly __typename?: 'conference_Configuration', readonly key: Conference_ConfigurationKey_Enum, readonly value: any }> };
+
+export type GetEventDetailsQueryVariables = Exact<{
+  eventId: Scalars['uuid'];
+}>;
+
+
+export type GetEventDetailsQuery = { readonly __typename?: 'query_root', readonly schedule_Event_by_pk?: Maybe<{ readonly __typename?: 'schedule_Event', readonly id: any, readonly conferenceId: any, readonly startTime: any, readonly name: string, readonly durationSeconds: number, readonly endTime?: Maybe<any>, readonly intendedRoomModeName: Room_Mode_Enum, readonly eventVonageSession?: Maybe<{ readonly __typename?: 'video_EventVonageSession', readonly id: any, readonly sessionId: string }> }> };
+
+export type RoomEventDetailsFragment = { readonly __typename?: 'schedule_Event', readonly id: any, readonly conferenceId: any, readonly startTime: any, readonly name: string, readonly durationSeconds: number, readonly endTime?: Maybe<any>, readonly intendedRoomModeName: Room_Mode_Enum, readonly eventVonageSession?: Maybe<{ readonly __typename?: 'video_EventVonageSession', readonly id: any, readonly sessionId: string }> };
 
 export type VideoPlayer_GetElementQueryVariables = Exact<{
   elementId: Scalars['uuid'];
@@ -37800,35 +37813,6 @@ export const MyBackstages_EventFragmentDoc = gql`
   startTime
 }
     `;
-export const EventParticipantStreamDetailsFragmentDoc = gql`
-    fragment EventParticipantStreamDetails on video_EventParticipantStream {
-  id
-  registrant {
-    id
-    displayName
-  }
-  conferenceId
-  eventId
-  vonageStreamType
-  vonageStreamId
-  registrantId
-}
-    `;
-export const RoomEventDetailsFragmentDoc = gql`
-    fragment RoomEventDetails on schedule_Event {
-  id
-  conferenceId
-  startTime
-  name
-  durationSeconds
-  endTime
-  intendedRoomModeName
-  eventVonageSession {
-    id
-    sessionId
-  }
-}
-    `;
 export const PrefetchShuffleQueueEntryDataFragmentDoc = gql`
     fragment PrefetchShuffleQueueEntryData on room_ShuffleQueueEntry {
   id
@@ -37968,6 +37952,35 @@ export const RoomSponsorContent_ItemDataFragmentDoc = gql`
   }
 }
     ${RoomSponsorContent_ElementDataFragmentDoc}`;
+export const EventParticipantStreamDetailsFragmentDoc = gql`
+    fragment EventParticipantStreamDetails on video_EventParticipantStream {
+  id
+  registrant {
+    id
+    displayName
+  }
+  conferenceId
+  eventId
+  vonageStreamType
+  vonageStreamId
+  registrantId
+}
+    `;
+export const RoomEventDetailsFragmentDoc = gql`
+    fragment RoomEventDetails on schedule_Event {
+  id
+  conferenceId
+  startTime
+  name
+  durationSeconds
+  endTime
+  intendedRoomModeName
+  eventVonageSession {
+    id
+    sessionId
+  }
+}
+    `;
 export const RoomListRoomDetailsFragmentDoc = gql`
     fragment RoomListRoomDetails on room_Room {
   id
@@ -40503,316 +40516,6 @@ export function useRegistrant_RegistrantCreateRoomMutation(baseOptions?: Apollo.
 export type Registrant_RegistrantCreateRoomMutationHookResult = ReturnType<typeof useRegistrant_RegistrantCreateRoomMutation>;
 export type Registrant_RegistrantCreateRoomMutationResult = Apollo.MutationResult<Registrant_RegistrantCreateRoomMutation>;
 export type Registrant_RegistrantCreateRoomMutationOptions = Apollo.BaseMutationOptions<Registrant_RegistrantCreateRoomMutation, Registrant_RegistrantCreateRoomMutationVariables>;
-export const UpdateEventVonageSessionLayoutDocument = gql`
-    mutation UpdateEventVonageSessionLayout($eventVonageSessionId: uuid!, $layoutData: jsonb!) {
-  update_video_EventVonageSession_by_pk(
-    pk_columns: {id: $eventVonageSessionId}
-    _set: {layoutData: $layoutData}
-  ) {
-    id
-  }
-}
-    `;
-export type UpdateEventVonageSessionLayoutMutationFn = Apollo.MutationFunction<UpdateEventVonageSessionLayoutMutation, UpdateEventVonageSessionLayoutMutationVariables>;
-
-/**
- * __useUpdateEventVonageSessionLayoutMutation__
- *
- * To run a mutation, you first call `useUpdateEventVonageSessionLayoutMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateEventVonageSessionLayoutMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [updateEventVonageSessionLayoutMutation, { data, loading, error }] = useUpdateEventVonageSessionLayoutMutation({
- *   variables: {
- *      eventVonageSessionId: // value for 'eventVonageSessionId'
- *      layoutData: // value for 'layoutData'
- *   },
- * });
- */
-export function useUpdateEventVonageSessionLayoutMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventVonageSessionLayoutMutation, UpdateEventVonageSessionLayoutMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateEventVonageSessionLayoutMutation, UpdateEventVonageSessionLayoutMutationVariables>(UpdateEventVonageSessionLayoutDocument, options);
-      }
-export type UpdateEventVonageSessionLayoutMutationHookResult = ReturnType<typeof useUpdateEventVonageSessionLayoutMutation>;
-export type UpdateEventVonageSessionLayoutMutationResult = Apollo.MutationResult<UpdateEventVonageSessionLayoutMutation>;
-export type UpdateEventVonageSessionLayoutMutationOptions = Apollo.BaseMutationOptions<UpdateEventVonageSessionLayoutMutation, UpdateEventVonageSessionLayoutMutationVariables>;
-export const GetEventParticipantStreamsDocument = gql`
-    subscription GetEventParticipantStreams($eventId: uuid!) {
-  video_EventParticipantStream(where: {eventId: {_eq: $eventId}}) {
-    ...EventParticipantStreamDetails
-  }
-}
-    ${EventParticipantStreamDetailsFragmentDoc}`;
-
-/**
- * __useGetEventParticipantStreamsSubscription__
- *
- * To run a query within a React component, call `useGetEventParticipantStreamsSubscription` and pass it any options that fit your needs.
- * When your component renders, `useGetEventParticipantStreamsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetEventParticipantStreamsSubscription({
- *   variables: {
- *      eventId: // value for 'eventId'
- *   },
- * });
- */
-export function useGetEventParticipantStreamsSubscription(baseOptions: Apollo.SubscriptionHookOptions<GetEventParticipantStreamsSubscription, GetEventParticipantStreamsSubscriptionVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useSubscription<GetEventParticipantStreamsSubscription, GetEventParticipantStreamsSubscriptionVariables>(GetEventParticipantStreamsDocument, options);
-      }
-export type GetEventParticipantStreamsSubscriptionHookResult = ReturnType<typeof useGetEventParticipantStreamsSubscription>;
-export type GetEventParticipantStreamsSubscriptionResult = Apollo.SubscriptionResult<GetEventParticipantStreamsSubscription>;
-export const GetEventVonageTokenDocument = gql`
-    mutation GetEventVonageToken($eventId: uuid!) {
-  joinEventVonageSession(eventId: $eventId) {
-    accessToken
-  }
-}
-    `;
-export type GetEventVonageTokenMutationFn = Apollo.MutationFunction<GetEventVonageTokenMutation, GetEventVonageTokenMutationVariables>;
-
-/**
- * __useGetEventVonageTokenMutation__
- *
- * To run a mutation, you first call `useGetEventVonageTokenMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useGetEventVonageTokenMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [getEventVonageTokenMutation, { data, loading, error }] = useGetEventVonageTokenMutation({
- *   variables: {
- *      eventId: // value for 'eventId'
- *   },
- * });
- */
-export function useGetEventVonageTokenMutation(baseOptions?: Apollo.MutationHookOptions<GetEventVonageTokenMutation, GetEventVonageTokenMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<GetEventVonageTokenMutation, GetEventVonageTokenMutationVariables>(GetEventVonageTokenDocument, options);
-      }
-export type GetEventVonageTokenMutationHookResult = ReturnType<typeof useGetEventVonageTokenMutation>;
-export type GetEventVonageTokenMutationResult = Apollo.MutationResult<GetEventVonageTokenMutation>;
-export type GetEventVonageTokenMutationOptions = Apollo.BaseMutationOptions<GetEventVonageTokenMutation, GetEventVonageTokenMutationVariables>;
-export const GetEventDetailsDocument = gql`
-    query GetEventDetails($eventId: uuid!) {
-  schedule_Event_by_pk(id: $eventId) {
-    ...RoomEventDetails
-  }
-}
-    ${RoomEventDetailsFragmentDoc}`;
-
-/**
- * __useGetEventDetailsQuery__
- *
- * To run a query within a React component, call `useGetEventDetailsQuery` and pass it any options that fit your needs.
- * When your component renders, `useGetEventDetailsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useGetEventDetailsQuery({
- *   variables: {
- *      eventId: // value for 'eventId'
- *   },
- * });
- */
-export function useGetEventDetailsQuery(baseOptions: Apollo.QueryHookOptions<GetEventDetailsQuery, GetEventDetailsQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<GetEventDetailsQuery, GetEventDetailsQueryVariables>(GetEventDetailsDocument, options);
-      }
-export function useGetEventDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetEventDetailsQuery, GetEventDetailsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<GetEventDetailsQuery, GetEventDetailsQueryVariables>(GetEventDetailsDocument, options);
-        }
-export type GetEventDetailsQueryHookResult = ReturnType<typeof useGetEventDetailsQuery>;
-export type GetEventDetailsLazyQueryHookResult = ReturnType<typeof useGetEventDetailsLazyQuery>;
-export type GetEventDetailsQueryResult = Apollo.QueryResult<GetEventDetailsQuery, GetEventDetailsQueryVariables>;
-export const ImmediateSwitch_GetElementsDocument = gql`
-    query ImmediateSwitch_GetElements($eventId: uuid!) {
-  schedule_Event_by_pk(id: $eventId) {
-    id
-    item {
-      id
-      title
-      elements(
-        where: {typeName: {_in: [VIDEO_BROADCAST, VIDEO_FILE, VIDEO_PREPUBLISH]}}
-      ) {
-        id
-        name
-      }
-    }
-    exhibition {
-      id
-      items {
-        id
-        item {
-          id
-          title
-          elements(
-            where: {typeName: {_in: [VIDEO_BROADCAST, VIDEO_FILE, VIDEO_PREPUBLISH]}}
-          ) {
-            id
-            name
-          }
-        }
-      }
-    }
-  }
-}
-    `;
-
-/**
- * __useImmediateSwitch_GetElementsQuery__
- *
- * To run a query within a React component, call `useImmediateSwitch_GetElementsQuery` and pass it any options that fit your needs.
- * When your component renders, `useImmediateSwitch_GetElementsQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useImmediateSwitch_GetElementsQuery({
- *   variables: {
- *      eventId: // value for 'eventId'
- *   },
- * });
- */
-export function useImmediateSwitch_GetElementsQuery(baseOptions: Apollo.QueryHookOptions<ImmediateSwitch_GetElementsQuery, ImmediateSwitch_GetElementsQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ImmediateSwitch_GetElementsQuery, ImmediateSwitch_GetElementsQueryVariables>(ImmediateSwitch_GetElementsDocument, options);
-      }
-export function useImmediateSwitch_GetElementsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ImmediateSwitch_GetElementsQuery, ImmediateSwitch_GetElementsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ImmediateSwitch_GetElementsQuery, ImmediateSwitch_GetElementsQueryVariables>(ImmediateSwitch_GetElementsDocument, options);
-        }
-export type ImmediateSwitch_GetElementsQueryHookResult = ReturnType<typeof useImmediateSwitch_GetElementsQuery>;
-export type ImmediateSwitch_GetElementsLazyQueryHookResult = ReturnType<typeof useImmediateSwitch_GetElementsLazyQuery>;
-export type ImmediateSwitch_GetElementsQueryResult = Apollo.QueryResult<ImmediateSwitch_GetElementsQuery, ImmediateSwitch_GetElementsQueryVariables>;
-export const ImmediateSwitch_CreateDocument = gql`
-    mutation ImmediateSwitch_Create($data: jsonb!, $eventId: uuid!, $conferenceId: uuid!) {
-  insert_video_ImmediateSwitch_one(
-    object: {data: $data, eventId: $eventId, conferenceId: $conferenceId}
-  ) {
-    id
-  }
-}
-    `;
-export type ImmediateSwitch_CreateMutationFn = Apollo.MutationFunction<ImmediateSwitch_CreateMutation, ImmediateSwitch_CreateMutationVariables>;
-
-/**
- * __useImmediateSwitch_CreateMutation__
- *
- * To run a mutation, you first call `useImmediateSwitch_CreateMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useImmediateSwitch_CreateMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [immediateSwitchCreateMutation, { data, loading, error }] = useImmediateSwitch_CreateMutation({
- *   variables: {
- *      data: // value for 'data'
- *      eventId: // value for 'eventId'
- *      conferenceId: // value for 'conferenceId'
- *   },
- * });
- */
-export function useImmediateSwitch_CreateMutation(baseOptions?: Apollo.MutationHookOptions<ImmediateSwitch_CreateMutation, ImmediateSwitch_CreateMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<ImmediateSwitch_CreateMutation, ImmediateSwitch_CreateMutationVariables>(ImmediateSwitch_CreateDocument, options);
-      }
-export type ImmediateSwitch_CreateMutationHookResult = ReturnType<typeof useImmediateSwitch_CreateMutation>;
-export type ImmediateSwitch_CreateMutationResult = Apollo.MutationResult<ImmediateSwitch_CreateMutation>;
-export type ImmediateSwitch_CreateMutationOptions = Apollo.BaseMutationOptions<ImmediateSwitch_CreateMutation, ImmediateSwitch_CreateMutationVariables>;
-export const LiveIndicator_GetLatestDocument = gql`
-    query LiveIndicator_GetLatest($eventId: uuid!) {
-  video_ImmediateSwitch(
-    order_by: {executedAt: desc_nulls_last}
-    where: {eventId: {_eq: $eventId}, executedAt: {_is_null: false}}
-    limit: 1
-  ) {
-    id
-    data
-    executedAt
-  }
-}
-    `;
-
-/**
- * __useLiveIndicator_GetLatestQuery__
- *
- * To run a query within a React component, call `useLiveIndicator_GetLatestQuery` and pass it any options that fit your needs.
- * When your component renders, `useLiveIndicator_GetLatestQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useLiveIndicator_GetLatestQuery({
- *   variables: {
- *      eventId: // value for 'eventId'
- *   },
- * });
- */
-export function useLiveIndicator_GetLatestQuery(baseOptions: Apollo.QueryHookOptions<LiveIndicator_GetLatestQuery, LiveIndicator_GetLatestQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<LiveIndicator_GetLatestQuery, LiveIndicator_GetLatestQueryVariables>(LiveIndicator_GetLatestDocument, options);
-      }
-export function useLiveIndicator_GetLatestLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LiveIndicator_GetLatestQuery, LiveIndicator_GetLatestQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<LiveIndicator_GetLatestQuery, LiveIndicator_GetLatestQueryVariables>(LiveIndicator_GetLatestDocument, options);
-        }
-export type LiveIndicator_GetLatestQueryHookResult = ReturnType<typeof useLiveIndicator_GetLatestQuery>;
-export type LiveIndicator_GetLatestLazyQueryHookResult = ReturnType<typeof useLiveIndicator_GetLatestLazyQuery>;
-export type LiveIndicator_GetLatestQueryResult = Apollo.QueryResult<LiveIndicator_GetLatestQuery, LiveIndicator_GetLatestQueryVariables>;
-export const LiveIndicator_GetElementDocument = gql`
-    query LiveIndicator_GetElement($elementId: uuid!) {
-  content_Element_by_pk(id: $elementId) {
-    id
-    data
-  }
-}
-    `;
-
-/**
- * __useLiveIndicator_GetElementQuery__
- *
- * To run a query within a React component, call `useLiveIndicator_GetElementQuery` and pass it any options that fit your needs.
- * When your component renders, `useLiveIndicator_GetElementQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useLiveIndicator_GetElementQuery({
- *   variables: {
- *      elementId: // value for 'elementId'
- *   },
- * });
- */
-export function useLiveIndicator_GetElementQuery(baseOptions: Apollo.QueryHookOptions<LiveIndicator_GetElementQuery, LiveIndicator_GetElementQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<LiveIndicator_GetElementQuery, LiveIndicator_GetElementQueryVariables>(LiveIndicator_GetElementDocument, options);
-      }
-export function useLiveIndicator_GetElementLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LiveIndicator_GetElementQuery, LiveIndicator_GetElementQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<LiveIndicator_GetElementQuery, LiveIndicator_GetElementQueryVariables>(LiveIndicator_GetElementDocument, options);
-        }
-export type LiveIndicator_GetElementQueryHookResult = ReturnType<typeof useLiveIndicator_GetElementQuery>;
-export type LiveIndicator_GetElementLazyQueryHookResult = ReturnType<typeof useLiveIndicator_GetElementLazyQuery>;
-export type LiveIndicator_GetElementQueryResult = Apollo.QueryResult<LiveIndicator_GetElementQuery, LiveIndicator_GetElementQueryVariables>;
 export const Room_GetEventsDocument = gql`
     query Room_GetEvents($roomId: uuid!, $now: timestamptz!, $cutoff: timestamptz!) {
   schedule_Event(
@@ -40993,6 +40696,39 @@ export function useRoomPage_GetRoomChannelStackLazyQuery(baseOptions?: Apollo.La
 export type RoomPage_GetRoomChannelStackQueryHookResult = ReturnType<typeof useRoomPage_GetRoomChannelStackQuery>;
 export type RoomPage_GetRoomChannelStackLazyQueryHookResult = ReturnType<typeof useRoomPage_GetRoomChannelStackLazyQuery>;
 export type RoomPage_GetRoomChannelStackQueryResult = Apollo.QueryResult<RoomPage_GetRoomChannelStackQuery, RoomPage_GetRoomChannelStackQueryVariables>;
+export const GetEventVonageTokenDocument = gql`
+    mutation GetEventVonageToken($eventId: uuid!) {
+  joinEventVonageSession(eventId: $eventId) {
+    accessToken
+  }
+}
+    `;
+export type GetEventVonageTokenMutationFn = Apollo.MutationFunction<GetEventVonageTokenMutation, GetEventVonageTokenMutationVariables>;
+
+/**
+ * __useGetEventVonageTokenMutation__
+ *
+ * To run a mutation, you first call `useGetEventVonageTokenMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useGetEventVonageTokenMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [getEventVonageTokenMutation, { data, loading, error }] = useGetEventVonageTokenMutation({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *   },
+ * });
+ */
+export function useGetEventVonageTokenMutation(baseOptions?: Apollo.MutationHookOptions<GetEventVonageTokenMutation, GetEventVonageTokenMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<GetEventVonageTokenMutation, GetEventVonageTokenMutationVariables>(GetEventVonageTokenDocument, options);
+      }
+export type GetEventVonageTokenMutationHookResult = ReturnType<typeof useGetEventVonageTokenMutation>;
+export type GetEventVonageTokenMutationResult = Apollo.MutationResult<GetEventVonageTokenMutation>;
+export type GetEventVonageTokenMutationOptions = Apollo.BaseMutationOptions<GetEventVonageTokenMutation, GetEventVonageTokenMutationVariables>;
 export const GetEventVonageDetailsDocument = gql`
     query GetEventVonageDetails($eventId: uuid!) {
   schedule_Event_by_pk(id: $eventId) {
@@ -41067,6 +40803,322 @@ export function useRoomSponsorContent_GetElementsLazyQuery(baseOptions?: Apollo.
 export type RoomSponsorContent_GetElementsQueryHookResult = ReturnType<typeof useRoomSponsorContent_GetElementsQuery>;
 export type RoomSponsorContent_GetElementsLazyQueryHookResult = ReturnType<typeof useRoomSponsorContent_GetElementsLazyQuery>;
 export type RoomSponsorContent_GetElementsQueryResult = Apollo.QueryResult<RoomSponsorContent_GetElementsQuery, RoomSponsorContent_GetElementsQueryVariables>;
+export const GetEventParticipantStreamsDocument = gql`
+    subscription GetEventParticipantStreams($eventId: uuid!) {
+  video_EventParticipantStream(where: {eventId: {_eq: $eventId}}) {
+    ...EventParticipantStreamDetails
+  }
+}
+    ${EventParticipantStreamDetailsFragmentDoc}`;
+
+/**
+ * __useGetEventParticipantStreamsSubscription__
+ *
+ * To run a query within a React component, call `useGetEventParticipantStreamsSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useGetEventParticipantStreamsSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetEventParticipantStreamsSubscription({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *   },
+ * });
+ */
+export function useGetEventParticipantStreamsSubscription(baseOptions: Apollo.SubscriptionHookOptions<GetEventParticipantStreamsSubscription, GetEventParticipantStreamsSubscriptionVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useSubscription<GetEventParticipantStreamsSubscription, GetEventParticipantStreamsSubscriptionVariables>(GetEventParticipantStreamsDocument, options);
+      }
+export type GetEventParticipantStreamsSubscriptionHookResult = ReturnType<typeof useGetEventParticipantStreamsSubscription>;
+export type GetEventParticipantStreamsSubscriptionResult = Apollo.SubscriptionResult<GetEventParticipantStreamsSubscription>;
+export const ImmediateSwitch_GetElementsDocument = gql`
+    query ImmediateSwitch_GetElements($eventId: uuid!) {
+  schedule_Event_by_pk(id: $eventId) {
+    id
+    item {
+      id
+      title
+      elements(
+        where: {typeName: {_in: [VIDEO_BROADCAST, VIDEO_FILE, VIDEO_PREPUBLISH]}}
+      ) {
+        id
+        name
+      }
+    }
+    exhibition {
+      id
+      items {
+        id
+        item {
+          id
+          title
+          elements(
+            where: {typeName: {_in: [VIDEO_BROADCAST, VIDEO_FILE, VIDEO_PREPUBLISH]}}
+          ) {
+            id
+            name
+          }
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useImmediateSwitch_GetElementsQuery__
+ *
+ * To run a query within a React component, call `useImmediateSwitch_GetElementsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useImmediateSwitch_GetElementsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useImmediateSwitch_GetElementsQuery({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *   },
+ * });
+ */
+export function useImmediateSwitch_GetElementsQuery(baseOptions: Apollo.QueryHookOptions<ImmediateSwitch_GetElementsQuery, ImmediateSwitch_GetElementsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<ImmediateSwitch_GetElementsQuery, ImmediateSwitch_GetElementsQueryVariables>(ImmediateSwitch_GetElementsDocument, options);
+      }
+export function useImmediateSwitch_GetElementsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ImmediateSwitch_GetElementsQuery, ImmediateSwitch_GetElementsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<ImmediateSwitch_GetElementsQuery, ImmediateSwitch_GetElementsQueryVariables>(ImmediateSwitch_GetElementsDocument, options);
+        }
+export type ImmediateSwitch_GetElementsQueryHookResult = ReturnType<typeof useImmediateSwitch_GetElementsQuery>;
+export type ImmediateSwitch_GetElementsLazyQueryHookResult = ReturnType<typeof useImmediateSwitch_GetElementsLazyQuery>;
+export type ImmediateSwitch_GetElementsQueryResult = Apollo.QueryResult<ImmediateSwitch_GetElementsQuery, ImmediateSwitch_GetElementsQueryVariables>;
+export const ImmediateSwitch_CreateDocument = gql`
+    mutation ImmediateSwitch_Create($data: jsonb!, $eventId: uuid!, $conferenceId: uuid!) {
+  insert_video_ImmediateSwitch_one(
+    object: {data: $data, eventId: $eventId, conferenceId: $conferenceId}
+  ) {
+    id
+  }
+}
+    `;
+export type ImmediateSwitch_CreateMutationFn = Apollo.MutationFunction<ImmediateSwitch_CreateMutation, ImmediateSwitch_CreateMutationVariables>;
+
+/**
+ * __useImmediateSwitch_CreateMutation__
+ *
+ * To run a mutation, you first call `useImmediateSwitch_CreateMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useImmediateSwitch_CreateMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [immediateSwitchCreateMutation, { data, loading, error }] = useImmediateSwitch_CreateMutation({
+ *   variables: {
+ *      data: // value for 'data'
+ *      eventId: // value for 'eventId'
+ *      conferenceId: // value for 'conferenceId'
+ *   },
+ * });
+ */
+export function useImmediateSwitch_CreateMutation(baseOptions?: Apollo.MutationHookOptions<ImmediateSwitch_CreateMutation, ImmediateSwitch_CreateMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ImmediateSwitch_CreateMutation, ImmediateSwitch_CreateMutationVariables>(ImmediateSwitch_CreateDocument, options);
+      }
+export type ImmediateSwitch_CreateMutationHookResult = ReturnType<typeof useImmediateSwitch_CreateMutation>;
+export type ImmediateSwitch_CreateMutationResult = Apollo.MutationResult<ImmediateSwitch_CreateMutation>;
+export type ImmediateSwitch_CreateMutationOptions = Apollo.BaseMutationOptions<ImmediateSwitch_CreateMutation, ImmediateSwitch_CreateMutationVariables>;
+export const UpdateEventVonageSessionLayoutDocument = gql`
+    mutation UpdateEventVonageSessionLayout($eventVonageSessionId: uuid!, $layoutData: jsonb!) {
+  update_video_EventVonageSession_by_pk(
+    pk_columns: {id: $eventVonageSessionId}
+    _set: {layoutData: $layoutData}
+  ) {
+    id
+  }
+}
+    `;
+export type UpdateEventVonageSessionLayoutMutationFn = Apollo.MutationFunction<UpdateEventVonageSessionLayoutMutation, UpdateEventVonageSessionLayoutMutationVariables>;
+
+/**
+ * __useUpdateEventVonageSessionLayoutMutation__
+ *
+ * To run a mutation, you first call `useUpdateEventVonageSessionLayoutMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateEventVonageSessionLayoutMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateEventVonageSessionLayoutMutation, { data, loading, error }] = useUpdateEventVonageSessionLayoutMutation({
+ *   variables: {
+ *      eventVonageSessionId: // value for 'eventVonageSessionId'
+ *      layoutData: // value for 'layoutData'
+ *   },
+ * });
+ */
+export function useUpdateEventVonageSessionLayoutMutation(baseOptions?: Apollo.MutationHookOptions<UpdateEventVonageSessionLayoutMutation, UpdateEventVonageSessionLayoutMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateEventVonageSessionLayoutMutation, UpdateEventVonageSessionLayoutMutationVariables>(UpdateEventVonageSessionLayoutDocument, options);
+      }
+export type UpdateEventVonageSessionLayoutMutationHookResult = ReturnType<typeof useUpdateEventVonageSessionLayoutMutation>;
+export type UpdateEventVonageSessionLayoutMutationResult = Apollo.MutationResult<UpdateEventVonageSessionLayoutMutation>;
+export type UpdateEventVonageSessionLayoutMutationOptions = Apollo.BaseMutationOptions<UpdateEventVonageSessionLayoutMutation, UpdateEventVonageSessionLayoutMutationVariables>;
+export const LiveIndicator_GetLatestDocument = gql`
+    query LiveIndicator_GetLatest($eventId: uuid!) {
+  video_ImmediateSwitch(
+    order_by: {executedAt: desc_nulls_last}
+    where: {eventId: {_eq: $eventId}, executedAt: {_is_null: false}}
+    limit: 1
+  ) {
+    id
+    data
+    executedAt
+  }
+}
+    `;
+
+/**
+ * __useLiveIndicator_GetLatestQuery__
+ *
+ * To run a query within a React component, call `useLiveIndicator_GetLatestQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLiveIndicator_GetLatestQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useLiveIndicator_GetLatestQuery({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *   },
+ * });
+ */
+export function useLiveIndicator_GetLatestQuery(baseOptions: Apollo.QueryHookOptions<LiveIndicator_GetLatestQuery, LiveIndicator_GetLatestQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<LiveIndicator_GetLatestQuery, LiveIndicator_GetLatestQueryVariables>(LiveIndicator_GetLatestDocument, options);
+      }
+export function useLiveIndicator_GetLatestLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LiveIndicator_GetLatestQuery, LiveIndicator_GetLatestQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<LiveIndicator_GetLatestQuery, LiveIndicator_GetLatestQueryVariables>(LiveIndicator_GetLatestDocument, options);
+        }
+export type LiveIndicator_GetLatestQueryHookResult = ReturnType<typeof useLiveIndicator_GetLatestQuery>;
+export type LiveIndicator_GetLatestLazyQueryHookResult = ReturnType<typeof useLiveIndicator_GetLatestLazyQuery>;
+export type LiveIndicator_GetLatestQueryResult = Apollo.QueryResult<LiveIndicator_GetLatestQuery, LiveIndicator_GetLatestQueryVariables>;
+export const LiveIndicator_GetElementDocument = gql`
+    query LiveIndicator_GetElement($elementId: uuid!) {
+  content_Element_by_pk(id: $elementId) {
+    id
+    data
+  }
+}
+    `;
+
+/**
+ * __useLiveIndicator_GetElementQuery__
+ *
+ * To run a query within a React component, call `useLiveIndicator_GetElementQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLiveIndicator_GetElementQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useLiveIndicator_GetElementQuery({
+ *   variables: {
+ *      elementId: // value for 'elementId'
+ *   },
+ * });
+ */
+export function useLiveIndicator_GetElementQuery(baseOptions: Apollo.QueryHookOptions<LiveIndicator_GetElementQuery, LiveIndicator_GetElementQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<LiveIndicator_GetElementQuery, LiveIndicator_GetElementQueryVariables>(LiveIndicator_GetElementDocument, options);
+      }
+export function useLiveIndicator_GetElementLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LiveIndicator_GetElementQuery, LiveIndicator_GetElementQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<LiveIndicator_GetElementQuery, LiveIndicator_GetElementQueryVariables>(LiveIndicator_GetElementDocument, options);
+        }
+export type LiveIndicator_GetElementQueryHookResult = ReturnType<typeof useLiveIndicator_GetElementQuery>;
+export type LiveIndicator_GetElementLazyQueryHookResult = ReturnType<typeof useLiveIndicator_GetElementLazyQuery>;
+export type LiveIndicator_GetElementQueryResult = Apollo.QueryResult<LiveIndicator_GetElementQuery, LiveIndicator_GetElementQueryVariables>;
+export const EnableBackstageStreamPreviewDocument = gql`
+    query EnableBackstageStreamPreview($conferenceId: uuid!) {
+  conference_Configuration_by_pk(
+    key: ENABLE_BACKSTAGE_STREAM_PREVIEW
+    conferenceId: $conferenceId
+  ) {
+    key
+    value
+  }
+}
+    `;
+
+/**
+ * __useEnableBackstageStreamPreviewQuery__
+ *
+ * To run a query within a React component, call `useEnableBackstageStreamPreviewQuery` and pass it any options that fit your needs.
+ * When your component renders, `useEnableBackstageStreamPreviewQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useEnableBackstageStreamPreviewQuery({
+ *   variables: {
+ *      conferenceId: // value for 'conferenceId'
+ *   },
+ * });
+ */
+export function useEnableBackstageStreamPreviewQuery(baseOptions: Apollo.QueryHookOptions<EnableBackstageStreamPreviewQuery, EnableBackstageStreamPreviewQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<EnableBackstageStreamPreviewQuery, EnableBackstageStreamPreviewQueryVariables>(EnableBackstageStreamPreviewDocument, options);
+      }
+export function useEnableBackstageStreamPreviewLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<EnableBackstageStreamPreviewQuery, EnableBackstageStreamPreviewQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<EnableBackstageStreamPreviewQuery, EnableBackstageStreamPreviewQueryVariables>(EnableBackstageStreamPreviewDocument, options);
+        }
+export type EnableBackstageStreamPreviewQueryHookResult = ReturnType<typeof useEnableBackstageStreamPreviewQuery>;
+export type EnableBackstageStreamPreviewLazyQueryHookResult = ReturnType<typeof useEnableBackstageStreamPreviewLazyQuery>;
+export type EnableBackstageStreamPreviewQueryResult = Apollo.QueryResult<EnableBackstageStreamPreviewQuery, EnableBackstageStreamPreviewQueryVariables>;
+export const GetEventDetailsDocument = gql`
+    query GetEventDetails($eventId: uuid!) {
+  schedule_Event_by_pk(id: $eventId) {
+    ...RoomEventDetails
+  }
+}
+    ${RoomEventDetailsFragmentDoc}`;
+
+/**
+ * __useGetEventDetailsQuery__
+ *
+ * To run a query within a React component, call `useGetEventDetailsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetEventDetailsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetEventDetailsQuery({
+ *   variables: {
+ *      eventId: // value for 'eventId'
+ *   },
+ * });
+ */
+export function useGetEventDetailsQuery(baseOptions: Apollo.QueryHookOptions<GetEventDetailsQuery, GetEventDetailsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetEventDetailsQuery, GetEventDetailsQueryVariables>(GetEventDetailsDocument, options);
+      }
+export function useGetEventDetailsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetEventDetailsQuery, GetEventDetailsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetEventDetailsQuery, GetEventDetailsQueryVariables>(GetEventDetailsDocument, options);
+        }
+export type GetEventDetailsQueryHookResult = ReturnType<typeof useGetEventDetailsQuery>;
+export type GetEventDetailsLazyQueryHookResult = ReturnType<typeof useGetEventDetailsLazyQuery>;
+export type GetEventDetailsQueryResult = Apollo.QueryResult<GetEventDetailsQuery, GetEventDetailsQueryVariables>;
 export const VideoPlayer_GetElementDocument = gql`
     query VideoPlayer_GetElement($elementId: uuid!) {
   content_Element_by_pk(id: $elementId) {

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -1905,6 +1905,7 @@
             - REGISTRATION_URL
             - SUPPORT_ADDRESS
             - SCHEDULE_VIEW_VERSION
+            - ENABLE_BACKSTAGE_STREAM_PREVIEW
   update_permissions:
   - role: user
     permission:

--- a/hasura/migrations/1631544458147_insert_into_conference_ConfigurationKey/down.sql
+++ b/hasura/migrations/1631544458147_insert_into_conference_ConfigurationKey/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "conference"."ConfigurationKey" WHERE "name" = 'ENABLE_BACKSTAGE_STREAM_PREVIEW';

--- a/hasura/migrations/1631544458147_insert_into_conference_ConfigurationKey/up.sql
+++ b/hasura/migrations/1631544458147_insert_into_conference_ConfigurationKey/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO "conference"."ConfigurationKey"("name", "description") VALUES (E'ENABLE_BACKSTAGE_STREAM_PREVIEW', E'Boolean. Whether to enable the backstage stream preview or not.');


### PR DESCRIPTION
## What's new

This introduces a preview of the live-stream to the backstage. When the backstage goes live, the preview is automatically muted (but can be unmuted on demand). The preview can be disabled/hidden if needed (in case it impacts bandwidth). The preview is located with the backstage controls and is sticky - both of these may need reconsidering in future once we have feedback. This feature is enabled per-conference through a conference configuration record.

* This PR also fixes issues with the live indicator, particularly when the user plays out a video for which we do not know the duration.
* This PR also reorganises / renames some of the Room related code to make it a bit easier to understand.

## Details

- Related issue: #340 

## Upgrading

Instructions for other developers on how to upgrade their environment after
pulling this new code. Please tick (i.e. put an 'x' in) the boxes for the
actions that are necessary.

- [x] Run GraphQL Codegen in the frontend
- [ ] Re-install NPM packages in [insert name of folder]
- [x] Apply Hasura migrations
- [x] Apply Hasura metadata
- [x] Reload enum table/values in Hasura for `conference.Configuration`
- [ ] Update Auth0 rules
- [ ] Update environment variables
- [ ] Re-deploy AWS CDK [and update AWS environment variables]

## Deployment

Instructions for how to deploy these changes to production. Please tick (i.e.
put an 'x' in) the boxes for the actions that are necessary.

- [x] Apply migrations to Hasura
- [x] Apply metadata to Hasura
- [x] Reload enum table/values in Hasura for `conference.Configuration`
- [x] Re-deploy frontend
- [ ] Re-deploy actions service
- [ ] Re-deploy playout service
- [ ] Re-deploy real-time service
- [ ] Flush real-time service state (Redis/RabbitMQ)
- [ ] Update environment variables for [name of component]

Any other steps necessary to re-deploy?

To switch on this feature, add the relevant Conference Configuration record.