### PR TITLE
🗃 Part 2 of Unified Uploaders: The Admin UI and backend

### DIFF
--- a/frontend/src/aspects/Conference/Attend/Content/ItemElements.tsx
+++ b/frontend/src/aspects/Conference/Attend/Content/ItemElements.tsx
@@ -46,7 +46,30 @@ gql`
                 name
             }
         }
-        elements(where: { isHidden: { _eq: false } }) {
+        elements(
+            where: {
+                isHidden: { _eq: false }
+                _or: [
+                    # Component types which never get submitted
+                    {
+                        typeName: {
+                            _in: [
+                                ACTIVE_SOCIAL_ROOMS
+                                CONTENT_GROUP_LIST
+                                DIVIDER
+                                EXPLORE_PROGRAM_BUTTON
+                                EXPLORE_SCHEDULE_BUTTON
+                                LIVE_PROGRAM_ROOMS
+                                SPONSOR_BOOTHS
+                                WHOLE_SCHEDULE
+                            ]
+                        }
+                    }
+                    # All other element types
+                    { hasBeenSubmitted: { _eq: true } }
+                ]
+            }
+        ) {
             ...ElementData
         }
         itemPeople(order_by: { priority: asc }) {

--- a/frontend/src/aspects/Conference/Manage/Content/ManageContent.tsx
+++ b/frontend/src/aspects/Conference/Manage/Content/ManageContent.tsx
@@ -122,7 +122,7 @@ gql`
         conferenceId
     }
 
-    fragment ManageContent_ProgramPerson on collection_ProgramPerson {
+    fragment ManageContent_ProgramPerson on collection_ProgramPersonWithAccessToken {
         id
         name
         affiliation
@@ -135,7 +135,7 @@ gql`
         itemId
         priority
         roleName
-        person {
+        person: personWithAccessToken {
             ...ManageContent_ProgramPerson
         }
     }
@@ -811,15 +811,15 @@ export default function ManageContentV2(): JSX.Element {
         onClose: submissionsReview_OnClose,
     } = useDisclosure();
     const [sendSubmissionRequests_ItemIds, setSendSubmissionRequests_ItemIds] = useState<string[]>([]);
-    const [sendSubmissionRequests_UploaderIds, setSendSubmissionRequests_UploaderIds] = useState<string[] | null>(null);
+    const [sendSubmissionRequests_PersonIds, setSendSubmissionRequests_PersonIds] = useState<string[] | null>(null);
     const [submissionsReview_ItemIds, setSubmissionsReview_ItemIds] = useState<string[]>([]);
     const openSendSubmissionRequests = useCallback(
-        (itemId: string, uploaderIds: string[]) => {
+        (itemId: string, personIds: string[]) => {
             setSendSubmissionRequests_ItemIds([itemId]);
-            setSendSubmissionRequests_UploaderIds(uploaderIds);
+            setSendSubmissionRequests_PersonIds(personIds);
             sendSubmissionRequests_OnOpen();
         },
-        [setSendSubmissionRequests_ItemIds, sendSubmissionRequests_OnOpen, setSendSubmissionRequests_UploaderIds]
+        [setSendSubmissionRequests_ItemIds, sendSubmissionRequests_OnOpen, setSendSubmissionRequests_PersonIds]
     );
     const selectItemsForExport = useManageContent_SelectItemsForExportQuery({
         skip: true,
@@ -932,11 +932,11 @@ export default function ManageContentV2(): JSX.Element {
 
                                     People: item.itemPeople.map(
                                         (itemPerson) =>
-                                            `${itemPerson.priority ?? "N"}: ${itemPerson.person.id} (${
+                                            `${itemPerson.priority ?? "N"}: ${itemPerson.person?.id} (${
                                                 itemPerson.roleName
-                                            }) [${itemPerson.person.name} (${
-                                                itemPerson.person.affiliation ?? "No affiliation"
-                                            }) <${itemPerson.person.email ?? "No email"}>]`
+                                            }) [${itemPerson.person?.name} (${
+                                                itemPerson.person?.affiliation ?? "No affiliation"
+                                            }) <${itemPerson.person?.email ?? "No email"}>]`
                                     ),
                                 };
 
@@ -1099,7 +1099,7 @@ export default function ManageContentV2(): JSX.Element {
                             <Button
                                 onClick={() => {
                                     setSendSubmissionRequests_ItemIds(items.map((x) => x.id));
-                                    setSendSubmissionRequests_UploaderIds(null);
+                                    setSendSubmissionRequests_PersonIds(null);
                                     sendSubmissionRequests_OnOpen();
                                 }}
                             >
@@ -1119,7 +1119,7 @@ export default function ManageContentV2(): JSX.Element {
                                     onClick={() => {
                                         if (allItems?.content_Item) {
                                             setSendSubmissionRequests_ItemIds(allItems.content_Item.map((x) => x.id));
-                                            setSendSubmissionRequests_UploaderIds(null);
+                                            setSendSubmissionRequests_PersonIds(null);
                                             sendSubmissionRequests_OnOpen();
                                         }
                                     }}
@@ -1142,7 +1142,7 @@ export default function ManageContentV2(): JSX.Element {
                                                                   )
                                                                   .map((x) => x.id)
                                                           );
-                                                          setSendSubmissionRequests_UploaderIds(null);
+                                                          setSendSubmissionRequests_PersonIds(null);
                                                           sendSubmissionRequests_OnOpen();
                                                       }
                                                   }}
@@ -1358,7 +1358,7 @@ export default function ManageContentV2(): JSX.Element {
                 isOpen={sendSubmissionRequests_IsOpen}
                 onClose={sendSubmissionRequests_OnClose}
                 itemIds={sendSubmissionRequests_ItemIds}
-                uploaderIds={sendSubmissionRequests_UploaderIds}
+                personIds={sendSubmissionRequests_PersonIds}
             />
             <SubmissionsReviewModal
                 isOpen={submissionsReview_IsOpen}

--- a/frontend/src/aspects/Conference/Manage/Content/v2/BulkOperations/BulkOperationMenu.tsx
+++ b/frontend/src/aspects/Conference/Manage/Content/v2/BulkOperations/BulkOperationMenu.tsx
@@ -23,7 +23,7 @@ import { EditElementsPermissionGrantsModal } from "../Security/EditElementsPermi
 import { AddElementsModal } from "./AddElementsModal";
 import { CombineVideosModal } from "./CombineVideosModal";
 import { SelectElementsModal } from "./SelectElementsModal";
-import { SynchroniseUploadersModal } from "./SynchroniseUploadersModal";
+// import { SynchroniseUploadersModal } from "./SynchroniseUploadersModal";
 import { UpdateExhibitionDescriptiveItemsModal } from "./UpdateExhibitionDescriptiveItemsModal";
 import { UpdateLayoutModal } from "./UpdateLayoutModal";
 import { UpdateUploadsRemainingModal } from "./UpdateUploadsRemainingModal";
@@ -72,19 +72,19 @@ export function BulkOperationMenu({
                 });
             },
         },
-        {
-            label: "Synchronise uploaders",
-            value: "SYNCHRONISE_UPLOADERS",
-            operation: (items) => {
-                setActiveOperation({
-                    operation: "SYNCHRONISE_UPLOADERS",
-                    items: items,
-                    step: "SELECT",
-                    elementsByItem: [],
-                    restrictToTypes: null,
-                });
-            },
-        },
+        // {
+        //     label: "Synchronise uploaders",
+        //     value: "SYNCHRONISE_UPLOADERS",
+        //     operation: (items) => {
+        //         setActiveOperation({
+        //             operation: "SYNCHRONISE_UPLOADERS",
+        //             items: items,
+        //             step: "SELECT",
+        //             elementsByItem: [],
+        //             restrictToTypes: null,
+        //         });
+        //     },
+        // },
         {
             label: "Edit element uploads remaining",
             value: "UPDATE_UPLOADS_REMAINING",
@@ -315,7 +315,7 @@ export function BulkOperationMenu({
                 isOpen={
                     (activeOperation?.operation === "SECURITY" ||
                         activeOperation?.operation === "COMBINE_VIDEOS" ||
-                        activeOperation?.operation === "SYNCHRONISE_UPLOADERS" ||
+                        // activeOperation?.operation === "SYNCHRONISE_UPLOADERS" ||
                         activeOperation?.operation === "UPDATE_UPLOADS_REMAINING" ||
                         activeOperation?.operation === "ELEMENTS_LAYOUT") &&
                     activeOperation?.step === "SELECT"
@@ -328,7 +328,7 @@ export function BulkOperationMenu({
                     if (
                         activeOperation?.operation === "SECURITY" ||
                         activeOperation?.operation === "COMBINE_VIDEOS" ||
-                        activeOperation?.operation === "SYNCHRONISE_UPLOADERS" ||
+                        // activeOperation?.operation === "SYNCHRONISE_UPLOADERS" ||
                         activeOperation?.operation === "UPDATE_UPLOADS_REMAINING" ||
                         activeOperation?.operation === "ELEMENTS_LAYOUT"
                     ) {
@@ -400,13 +400,13 @@ export function BulkOperationMenu({
                 }}
                 elementsByItem={activeOperation?.elementsByItem ?? []}
             />
-            <SynchroniseUploadersModal
+            {/* <SynchroniseUploadersModal
                 isOpen={activeOperation?.operation === "SYNCHRONISE_UPLOADERS" && activeOperation?.step === "ACT"}
                 onClose={() => {
                     setActiveOperation(null);
                 }}
                 elementsByItem={activeOperation?.elementsByItem ?? []}
-            />
+            /> */}
             <UpdateUploadsRemainingModal
                 isOpen={activeOperation?.operation === "UPDATE_UPLOADS_REMAINING" && activeOperation?.step === "ACT"}
                 onClose={() => {

--- a/frontend/src/aspects/Conference/Manage/Content/v2/Element/EditUploaders.tsx
+++ b/frontend/src/aspects/Conference/Manage/Content/v2/Element/EditUploaders.tsx
@@ -1,53 +1,23 @@
-import { FetchResult, gql, MutationFunctionOptions, Reference } from "@apollo/client";
+import { FetchResult, gql, MutationFunctionOptions } from "@apollo/client";
 import {
-    Box,
-    Button,
-    ButtonGroup,
     chakra,
     Flex,
     FormControl,
     FormLabel,
     Heading,
     HStack,
-    Input,
-    Link,
-    List,
-    ListItem,
     NumberDecrementStepper,
     NumberIncrementStepper,
     NumberInput,
     NumberInputField,
     NumberInputStepper,
-    Popover,
-    PopoverBody,
-    PopoverContent,
-    PopoverFooter,
-    PopoverHeader,
-    PopoverTrigger,
-    Spinner,
-    Text,
-    Tooltip,
-    useColorModeValue,
-    useDisclosure,
-    useToast,
 } from "@chakra-ui/react";
-import * as R from "ramda";
-import React, { useRef, useState } from "react";
-import {
-    ManageContent_SelectUploadersDocument,
-    ManageContent_SelectUploadersQuery,
-    ManageContent_SelectUploadersQueryVariables,
+import React from "react";
+import type {
     ManageContent_UpdateElementMutation,
     ManageContent_UpdateElementMutationVariables,
-    ManageContent_UploaderFragment,
-    ManageContent_UploaderFragmentDoc,
-    useManageContent_DeleteUploadersMutation,
-    useManageContent_InsertUploadersMutation,
-    useManageContent_SelectUploadersQuery,
-    useManageContent_UpdateUploaderMutation,
 } from "../../../../../../generated/graphql";
 import { FAIcon } from "../../../../../Icons/FAIcon";
-import { useConference } from "../../../../useConference";
 
 gql`
     fragment ManageContent_Uploader on content_Uploader {
@@ -93,8 +63,8 @@ export function EditUploaders({
     uploadsRemaining,
     isUpdatingUploadable,
     updateUploadableElement,
-    openSendSubmissionRequests,
-}: {
+}: // openSendSubmissionRequests,
+{
     elementId: string;
     uploadsRemaining: number | null;
     isUpdatingUploadable: boolean;
@@ -106,222 +76,220 @@ export function EditUploaders({
     ) => Promise<FetchResult<ManageContent_UpdateElementMutation>>;
     openSendSubmissionRequests: (uploaderIds: string[]) => void;
 }): JSX.Element {
-    const conference = useConference();
-    const uploadersResponse = useManageContent_SelectUploadersQuery({
-        variables: {
-            elementId,
-        },
-    });
+    // const conference = useConference();
+    // const uploadersResponse = useManageContent_SelectUploadersQuery({
+    //     variables: {
+    //         elementId,
+    //     },
+    // });
 
-    const bgColor = useColorModeValue("purple.50", "purple.900");
+    // const bgColor = useColorModeValue("purple.50", "purple.900");
 
-    const { isOpen: addUploader_IsOpen, onOpen: addUploader_OnOpen, onClose: addUploader_OnClose } = useDisclosure();
-    const addUploader_InitialRef = useRef(null);
-    const [addUploader_Name, addUploader_SetName] = useState<string>("");
-    const [addUploader_Email, addUploader_SetEmail] = useState<string>("");
-    const [addUploader_EmailValid, addUploader_SetEmailValid] = useState<boolean>(false);
+    // const { isOpen: addUploader_IsOpen, onOpen: addUploader_OnOpen, onClose: addUploader_OnClose } = useDisclosure();
+    // const addUploader_InitialRef = useRef(null);
+    // const [addUploader_Name, addUploader_SetName] = useState<string>("");
+    // const [addUploader_Email, addUploader_SetEmail] = useState<string>("");
+    // const [addUploader_EmailValid, addUploader_SetEmailValid] = useState<boolean>(false);
 
-    const [insertUploaders, insertUploadersResponse] = useManageContent_InsertUploadersMutation({
-        update: (cache, response) => {
-            if (response.data?.insert_content_Uploader) {
-                const datas = response.data.insert_content_Uploader.returning;
-                datas.forEach((data) => {
-                    cache.writeFragment({
-                        data,
-                        fragment: ManageContent_UploaderFragmentDoc,
-                        fragmentName: "ManageContent_Uploader",
-                    });
+    // const [insertUploaders, insertUploadersResponse] = useManageContent_InsertUploadersMutation({
+    //     update: (cache, response) => {
+    //         if (response.data?.insert_content_Uploader) {
+    //             const datas = response.data.insert_content_Uploader.returning;
+    //             datas.forEach((data) => {
+    //                 cache.writeFragment({
+    //                     data,
+    //                     fragment: ManageContent_UploaderFragmentDoc,
+    //                     fragmentName: "ManageContent_Uploader",
+    //                 });
 
-                    {
-                        const query = cache.readQuery<
-                            ManageContent_SelectUploadersQuery,
-                            ManageContent_SelectUploadersQueryVariables
-                        >({
-                            query: ManageContent_SelectUploadersDocument,
-                            variables: {
-                                elementId: data.elementId,
-                            },
-                        });
-                        if (query) {
-                            cache.writeQuery<
-                                ManageContent_SelectUploadersQuery,
-                                ManageContent_SelectUploadersQueryVariables
-                            >({
-                                query: ManageContent_SelectUploadersDocument,
-                                data: {
-                                    ...query,
-                                    content_Uploader: [...query.content_Uploader.filter((x) => data.id !== x.id), data],
-                                },
-                                variables: {
-                                    elementId: data.elementId,
-                                },
-                            });
-                        }
-                    }
-                });
-            }
-        },
-    });
+    //                 {
+    //                     const query = cache.readQuery<
+    //                         ManageContent_SelectUploadersQuery,
+    //                         ManageContent_SelectUploadersQueryVariables
+    //                     >({
+    //                         query: ManageContent_SelectUploadersDocument,
+    //                         variables: {
+    //                             elementId: data.elementId,
+    //                         },
+    //                     });
+    //                     if (query) {
+    //                         cache.writeQuery<
+    //                             ManageContent_SelectUploadersQuery,
+    //                             ManageContent_SelectUploadersQueryVariables
+    //                         >({
+    //                             query: ManageContent_SelectUploadersDocument,
+    //                             data: {
+    //                                 ...query,
+    //                                 content_Uploader: [...query.content_Uploader.filter((x) => data.id !== x.id), data],
+    //                             },
+    //                             variables: {
+    //                                 elementId: data.elementId,
+    //                             },
+    //                         });
+    //                     }
+    //                 }
+    //             });
+    //         }
+    //     },
+    // });
 
-    const toast = useToast();
+    // const toast = useToast();
 
-    if (uploadersResponse.loading || !uploadersResponse.data) {
-        return <Spinner label="Loading uploaders" />;
-    } else {
-        return (
-            <>
-                <Flex w="100%" mt={4} mb={2} alignItems="center">
-                    <Tooltip label="Send submission request emails to all uploaders of this element.">
-                        <Button
-                            mr={3}
-                            size="xs"
-                            aria-label="Send submission request emails to all uploaders of this element."
-                            onClick={() => {
-                                openSendSubmissionRequests(
-                                    uploadersResponse.data?.content_Uploader.map((x) => x.id) ?? []
-                                );
-                            }}
-                            isLoading={insertUploadersResponse.loading}
-                            isDisabled={uploadersResponse.data.content_Uploader.length === 0}
-                        >
-                            <FAIcon iconStyle="s" icon="envelope" />
-                        </Button>
-                    </Tooltip>
-                    <Popover
-                        placement="bottom-start"
-                        isLazy
-                        initialFocusRef={addUploader_InitialRef}
-                        isOpen={addUploader_IsOpen}
-                        onClose={addUploader_OnClose}
+    // if (uploadersResponse.loading || !uploadersResponse.data) {
+    //     return <Spinner label="Loading uploaders" />;
+    // } else {
+    return (
+        <>
+            <Flex w="100%" mt={4} mb={2} alignItems="center">
+                {/* <Tooltip label="Send submission request emails to all uploaders of this element.">
+                    <Button
+                        mr={3}
+                        size="xs"
+                        aria-label="Send submission request emails to all uploaders of this element."
+                        onClick={() => {
+                            openSendSubmissionRequests(uploadersResponse.data?.content_Uploader.map((x) => x.id) ?? []);
+                        }}
+                        isLoading={insertUploadersResponse.loading}
+                        isDisabled={uploadersResponse.data.content_Uploader.length === 0}
                     >
-                        <PopoverTrigger>
-                            <Button
-                                size="xs"
-                                aria-label="Add uploader"
-                                mr={2}
-                                colorScheme="purple"
-                                onClick={addUploader_OnOpen}
-                            >
-                                <FAIcon iconStyle="s" icon="plus" />
-                            </Button>
-                        </PopoverTrigger>
-                        <PopoverContent bgColor={bgColor}>
-                            <PopoverHeader>Add uploader</PopoverHeader>
-                            <PopoverBody>
-                                <FormControl>
-                                    <FormLabel>Name</FormLabel>
-                                    <Input
-                                        placeholder="First-name last-name"
-                                        ref={addUploader_InitialRef}
-                                        value={addUploader_Name}
-                                        onChange={(ev) => {
-                                            addUploader_SetName(ev.target.value);
-                                        }}
-                                    />
-                                </FormControl>
-                                <FormControl mt={2}>
-                                    <FormLabel>Email</FormLabel>
-                                    <Input
-                                        type="email"
-                                        placeholder="email@example.org"
-                                        value={addUploader_Email}
-                                        onChange={(ev) => {
-                                            addUploader_SetEmail(ev.target.value);
-                                            addUploader_SetEmailValid(ev.target.validity.valid);
-                                        }}
-                                    />
-                                </FormControl>
-                            </PopoverBody>
-                            <PopoverFooter textAlign="right">
-                                <ButtonGroup>
-                                    <Button size="sm" onClick={addUploader_OnClose}>
-                                        Cancel
-                                    </Button>
-                                    <Button
-                                        colorScheme="purple"
-                                        size="sm"
-                                        onClick={async () => {
-                                            try {
-                                                await insertUploaders({
-                                                    variables: {
-                                                        objects: [
-                                                            {
-                                                                conferenceId: conference.id,
-                                                                email: addUploader_Email,
-                                                                name: addUploader_Name,
-                                                                elementId,
-                                                            },
-                                                        ],
-                                                    },
-                                                });
-                                                addUploader_OnClose();
-                                            } catch (e) {
-                                                toast({
-                                                    title: "Error adding uploader",
-                                                    description: e.message ?? e.toString(),
-                                                    isClosable: true,
-                                                    duration: 10000,
-                                                    position: "bottom",
-                                                    status: "error",
-                                                });
-                                            }
-                                        }}
-                                        isDisabled={
-                                            addUploader_Name.length === 0 ||
-                                            addUploader_Email.length === 0 ||
-                                            !addUploader_EmailValid
-                                        }
-                                        isLoading={insertUploadersResponse.loading}
-                                    >
-                                        Add
-                                    </Button>
-                                </ButtonGroup>
-                            </PopoverFooter>
-                        </PopoverContent>
-                    </Popover>
-                    <Heading as="h4" fontSize="sm" textAlign="left" pl={1} mr="auto">
-                        Uploaders
-                    </Heading>
-                    {uploadsRemaining !== null ? (
-                        <FormControl as={HStack} spacing={0} fontSize="sm" w="auto" alignItems="center">
-                            <FormLabel m={0} pr={1} pb={1}>
-                                Attempts remaining:
-                            </FormLabel>
-                            <NumberInput
-                                size="xs"
-                                minW={0}
-                                w="50px"
-                                isDisabled={isUpdatingUploadable}
-                                value={uploadsRemaining}
-                                onChange={(_valAsStr, valAsNum) => {
-                                    const newVal = Math.max(valAsNum, 0);
-                                    if (newVal !== uploadsRemaining) {
-                                        updateUploadableElement({
-                                            variables: {
-                                                elementId,
-                                                element: {
-                                                    uploadsRemaining: newVal,
+                        <FAIcon iconStyle="s" icon="envelope" />
+                    </Button>
+                </Tooltip>
+                <Popover
+                    placement="bottom-start"
+                    isLazy
+                    initialFocusRef={addUploader_InitialRef}
+                    isOpen={addUploader_IsOpen}
+                    onClose={addUploader_OnClose}
+                >
+                    <PopoverTrigger>
+                        <Button
+                            size="xs"
+                            aria-label="Add uploader"
+                            mr={2}
+                            colorScheme="purple"
+                            onClick={addUploader_OnOpen}
+                        >
+                            <FAIcon iconStyle="s" icon="plus" />
+                        </Button>
+                    </PopoverTrigger>
+                    <PopoverContent bgColor={bgColor}>
+                        <PopoverHeader>Add uploader</PopoverHeader>
+                        <PopoverBody>
+                            <FormControl>
+                                <FormLabel>Name</FormLabel>
+                                <Input
+                                    placeholder="First-name last-name"
+                                    ref={addUploader_InitialRef}
+                                    value={addUploader_Name}
+                                    onChange={(ev) => {
+                                        addUploader_SetName(ev.target.value);
+                                    }}
+                                />
+                            </FormControl>
+                            <FormControl mt={2}>
+                                <FormLabel>Email</FormLabel>
+                                <Input
+                                    type="email"
+                                    placeholder="email@example.org"
+                                    value={addUploader_Email}
+                                    onChange={(ev) => {
+                                        addUploader_SetEmail(ev.target.value);
+                                        addUploader_SetEmailValid(ev.target.validity.valid);
+                                    }}
+                                />
+                            </FormControl>
+                        </PopoverBody>
+                        <PopoverFooter textAlign="right">
+                            <ButtonGroup>
+                                <Button size="sm" onClick={addUploader_OnClose}>
+                                    Cancel
+                                </Button>
+                                <Button
+                                    colorScheme="purple"
+                                    size="sm"
+                                    onClick={async () => {
+                                        try {
+                                            await insertUploaders({
+                                                variables: {
+                                                    objects: [
+                                                        {
+                                                            conferenceId: conference.id,
+                                                            email: addUploader_Email,
+                                                            name: addUploader_Name,
+                                                            elementId,
+                                                        },
+                                                    ],
                                                 },
-                                            },
-                                        });
+                                            });
+                                            addUploader_OnClose();
+                                        } catch (e) {
+                                            toast({
+                                                title: "Error adding uploader",
+                                                description: e.message ?? e.toString(),
+                                                isClosable: true,
+                                                duration: 10000,
+                                                position: "bottom",
+                                                status: "error",
+                                            });
+                                        }
+                                    }}
+                                    isDisabled={
+                                        addUploader_Name.length === 0 ||
+                                        addUploader_Email.length === 0 ||
+                                        !addUploader_EmailValid
                                     }
-                                }}
-                            >
-                                <NumberInputField />
-                                <NumberInputStepper>
-                                    <NumberIncrementStepper aria-label="Increment" />
-                                    <NumberDecrementStepper aria-label="Decrement" />
-                                </NumberInputStepper>
-                            </NumberInput>
-                        </FormControl>
-                    ) : (
-                        <>
-                            <chakra.span fontSize="sm">Attempts remaining:</chakra.span>
-                            <FAIcon iconStyle="s" icon="infinity" fontSize="xs" ml={2} />
-                        </>
-                    )}
-                </Flex>
-                <Box overflow="auto" w="100%">
+                                    isLoading={insertUploadersResponse.loading}
+                                >
+                                    Add
+                                </Button>
+                            </ButtonGroup>
+                        </PopoverFooter>
+                    </PopoverContent>
+                </Popover> */}
+                <Heading as="h4" fontSize="sm" textAlign="left" pl={1} mr="auto">
+                    Uploads
+                </Heading>
+                {uploadsRemaining !== null ? (
+                    <FormControl as={HStack} spacing={0} fontSize="sm" w="auto" alignItems="center">
+                        <FormLabel m={0} pr={1} pb={1}>
+                            Attempts remaining:
+                        </FormLabel>
+                        <NumberInput
+                            size="xs"
+                            minW={0}
+                            w="50px"
+                            isDisabled={isUpdatingUploadable}
+                            value={uploadsRemaining}
+                            onChange={(_valAsStr, valAsNum) => {
+                                const newVal = Math.max(valAsNum, 0);
+                                if (newVal !== uploadsRemaining) {
+                                    updateUploadableElement({
+                                        variables: {
+                                            elementId,
+                                            element: {
+                                                uploadsRemaining: newVal,
+                                            },
+                                        },
+                                    });
+                                }
+                            }}
+                        >
+                            <NumberInputField />
+                            <NumberInputStepper>
+                                <NumberIncrementStepper aria-label="Increment" />
+                                <NumberDecrementStepper aria-label="Decrement" />
+                            </NumberInputStepper>
+                        </NumberInput>
+                    </FormControl>
+                ) : (
+                    <>
+                        <chakra.span fontSize="sm">Attempts remaining:</chakra.span>
+                        <FAIcon iconStyle="s" icon="infinity" fontSize="xs" ml={2} />
+                    </>
+                )}
+            </Flex>
+            {/* <Box overflow="auto" w="100%">
                     <List minW="max-content">
                         {R.sortBy((x) => x.name, uploadersResponse.data.content_Uploader).map((uploader) => (
                             <EditUploader
@@ -334,217 +302,217 @@ export function EditUploaders({
                             <ListItem>No uploaders listed. Use the plus button above to add an uploader.</ListItem>
                         ) : undefined}
                     </List>
-                </Box>
-            </>
-        );
-    }
-}
-
-function EditUploader({
-    uploader,
-    openSendSubmissionRequests,
-}: {
-    uploader: ManageContent_UploaderFragment;
-    openSendSubmissionRequests: (uploaderIds: string[]) => void;
-}): JSX.Element {
-    const [updateUploader, updateUploaderResponse] = useManageContent_UpdateUploaderMutation({
-        update: (cache, { data: _data }) => {
-            if (_data?.update_content_Uploader_by_pk) {
-                const data = _data.update_content_Uploader_by_pk;
-                cache.modify({
-                    fields: {
-                        content_Uploader(existingRefs: Reference[] = [], { readField }) {
-                            const newRef = cache.writeFragment({
-                                data,
-                                fragment: ManageContent_UploaderFragmentDoc,
-                                fragmentName: "ManageContent_Uploader",
-                            });
-                            if (existingRefs.some((ref) => readField("id", ref) === data.id)) {
-                                return existingRefs;
-                            }
-                            return [...existingRefs, newRef];
-                        },
-                    },
-                });
-            }
-        },
-    });
-    const [deleteUploaders, deleteUploadersResponse] = useManageContent_DeleteUploadersMutation({
-        update: (cache, response) => {
-            if (response.data?.delete_content_Uploader) {
-                const deletedIds = response.data.delete_content_Uploader.returning.map((x) => x.id);
-                cache.modify({
-                    fields: {
-                        content_Uploader(existingRefs: Reference[] = [], { readField }) {
-                            for (const deletedId of deletedIds) {
-                                cache.evict({
-                                    id: deletedId,
-                                    fieldName: "ManageContent_Uploader",
-                                    broadcast: true,
-                                });
-                            }
-                            return existingRefs.filter((ref) => !deletedIds.includes(readField("id", ref)));
-                        },
-                    },
-                });
-            }
-        },
-    });
-
-    const toast = useToast();
-
-    const [newName, setNewName] = useState<string>(uploader.name);
-    const [newEmail, setNewEmail] = useState<string>(uploader.email);
-    const [newEmailIsValid, setNewEmailIsValid] = useState<boolean>(true);
-    const [isEditing, setIsEditing] = useState<boolean>(false);
-
-    return (
-        <ListItem w="100%" mb={1}>
-            <Flex w="100%" alignItems="flex-start">
-                <Tooltip
-                    label={`Send submission request email to ${uploader.email}. ${uploader.emailsSentCount} previously sent.`}
-                >
-                    <Box mr={2} display="inline-block">
-                        <Button
-                            size="xs"
-                            aria-label={`Send submission request email to ${uploader.email}. ${uploader.emailsSentCount} previously sent.`}
-                            onClick={() => {
-                                openSendSubmissionRequests([uploader.id]);
-                            }}
-                            mr={2}
-                        >
-                            <FAIcon iconStyle="s" icon="envelope" />
-                            &nbsp;&nbsp;{uploader.emailsSentCount}
-                        </Button>
-                    </Box>
-                </Tooltip>
-                {!isEditing ? (
-                    <>
-                        <Tooltip label="Edit uploader">
-                            <Button
-                                size="xs"
-                                aria-label="Edit uploader"
-                                onClick={() => {
-                                    setIsEditing(true);
-                                }}
-                                mr={2}
-                                isLoading={updateUploaderResponse.loading}
-                            >
-                                <FAIcon iconStyle="s" icon="edit" />
-                            </Button>
-                        </Tooltip>
-                        <Text mr="auto">{uploader.name}</Text>
-                        <Text ml={2} mr={2}>
-                            &lt;
-                            <Link isExternal href={`mailto:${uploader.email}`}>
-                                {uploader.email}
-                            </Link>
-                            &gt;
-                        </Text>
-                    </>
-                ) : (
-                    <HStack alignItems="flex-start" mr="auto">
-                        <Tooltip label="Save changes">
-                            <Button
-                                size="xs"
-                                aria-label="Save changes"
-                                onClick={async () => {
-                                    try {
-                                        await updateUploader({
-                                            variables: {
-                                                id: uploader.id,
-                                                update: {
-                                                    email: newEmail,
-                                                    name: newName,
-                                                },
-                                            },
-                                        });
-
-                                        setIsEditing(false);
-                                    } catch (e) {
-                                        toast({
-                                            title: "Error updating uploader",
-                                            description: e.message ?? e.toString(),
-                                            isClosable: true,
-                                            duration: 10000,
-                                            position: "bottom",
-                                            status: "error",
-                                        });
-                                    }
-                                }}
-                                colorScheme="purple"
-                                isDisabled={newName === "" || newEmail === "" || !newEmailIsValid}
-                                isLoading={updateUploaderResponse.loading}
-                            >
-                                <FAIcon iconStyle="s" icon="save" />
-                            </Button>
-                        </Tooltip>
-                        <Tooltip label="Discard changes">
-                            <Button
-                                size="xs"
-                                aria-label="Discard changes"
-                                onClick={() => {
-                                    setNewName(uploader.name);
-                                    setNewEmail(uploader.email);
-                                    setIsEditing(false);
-                                }}
-                                mr={2}
-                                colorScheme="yellow"
-                                isLoading={updateUploaderResponse.loading}
-                            >
-                                <FAIcon iconStyle="s" icon="ban" />
-                            </Button>
-                        </Tooltip>
-                        <Input
-                            value={newName}
-                            size="sm"
-                            minW={70}
-                            onChange={(ev) => {
-                                setNewName(ev.target.value);
-                            }}
-                        />
-                        <Input
-                            type="email"
-                            value={newEmail}
-                            size="sm"
-                            minW={70}
-                            onChange={(ev) => {
-                                setNewEmail(ev.target.value);
-                                setNewEmailIsValid(ev.target.validity.valid);
-                            }}
-                        />
-                    </HStack>
-                )}
-                <Tooltip label="Delete uploader">
-                    <Button
-                        ml={2}
-                        size="xs"
-                        colorScheme="red"
-                        aria-label="Delete uploader"
-                        isLoading={deleteUploadersResponse.loading}
-                        onClick={async () => {
-                            try {
-                                await deleteUploaders({
-                                    variables: {
-                                        ids: [uploader.id],
-                                    },
-                                });
-                            } catch (e) {
-                                toast({
-                                    title: "Error deleting uploader",
-                                    description: e.message ?? e.toString(),
-                                    isClosable: true,
-                                    duration: 10000,
-                                    position: "bottom",
-                                    status: "error",
-                                });
-                            }
-                        }}
-                    >
-                        <FAIcon iconStyle="s" icon="trash-alt" />
-                    </Button>
-                </Tooltip>
-            </Flex>
-        </ListItem>
+                </Box> */}
+        </>
     );
+    // }
 }
+
+// function EditUploader({
+//     uploader,
+//     openSendSubmissionRequests,
+// }: {
+//     uploader: ManageContent_UploaderFragment;
+//     openSendSubmissionRequests: (uploaderIds: string[]) => void;
+// }): JSX.Element {
+//     const [updateUploader, updateUploaderResponse] = useManageContent_UpdateUploaderMutation({
+//         update: (cache, { data: _data }) => {
+//             if (_data?.update_content_Uploader_by_pk) {
+//                 const data = _data.update_content_Uploader_by_pk;
+//                 cache.modify({
+//                     fields: {
+//                         content_Uploader(existingRefs: Reference[] = [], { readField }) {
+//                             const newRef = cache.writeFragment({
+//                                 data,
+//                                 fragment: ManageContent_UploaderFragmentDoc,
+//                                 fragmentName: "ManageContent_Uploader",
+//                             });
+//                             if (existingRefs.some((ref) => readField("id", ref) === data.id)) {
+//                                 return existingRefs;
+//                             }
+//                             return [...existingRefs, newRef];
+//                         },
+//                     },
+//                 });
+//             }
+//         },
+//     });
+//     const [deleteUploaders, deleteUploadersResponse] = useManageContent_DeleteUploadersMutation({
+//         update: (cache, response) => {
+//             if (response.data?.delete_content_Uploader) {
+//                 const deletedIds = response.data.delete_content_Uploader.returning.map((x) => x.id);
+//                 cache.modify({
+//                     fields: {
+//                         content_Uploader(existingRefs: Reference[] = [], { readField }) {
+//                             for (const deletedId of deletedIds) {
+//                                 cache.evict({
+//                                     id: deletedId,
+//                                     fieldName: "ManageContent_Uploader",
+//                                     broadcast: true,
+//                                 });
+//                             }
+//                             return existingRefs.filter((ref) => !deletedIds.includes(readField("id", ref)));
+//                         },
+//                     },
+//                 });
+//             }
+//         },
+//     });
+
+//     const toast = useToast();
+
+//     const [newName, setNewName] = useState<string>(uploader.name);
+//     const [newEmail, setNewEmail] = useState<string>(uploader.email);
+//     const [newEmailIsValid, setNewEmailIsValid] = useState<boolean>(true);
+//     const [isEditing, setIsEditing] = useState<boolean>(false);
+
+//     return (
+//         <ListItem w="100%" mb={1}>
+//             <Flex w="100%" alignItems="flex-start">
+//                 <Tooltip
+//                     label={`Send submission request email to ${uploader.email}. ${uploader.emailsSentCount} previously sent.`}
+//                 >
+//                     <Box mr={2} display="inline-block">
+//                         <Button
+//                             size="xs"
+//                             aria-label={`Send submission request email to ${uploader.email}. ${uploader.emailsSentCount} previously sent.`}
+//                             onClick={() => {
+//                                 openSendSubmissionRequests([uploader.id]);
+//                             }}
+//                             mr={2}
+//                         >
+//                             <FAIcon iconStyle="s" icon="envelope" />
+//                             &nbsp;&nbsp;{uploader.emailsSentCount}
+//                         </Button>
+//                     </Box>
+//                 </Tooltip>
+//                 {!isEditing ? (
+//                     <>
+//                         <Tooltip label="Edit uploader">
+//                             <Button
+//                                 size="xs"
+//                                 aria-label="Edit uploader"
+//                                 onClick={() => {
+//                                     setIsEditing(true);
+//                                 }}
+//                                 mr={2}
+//                                 isLoading={updateUploaderResponse.loading}
+//                             >
+//                                 <FAIcon iconStyle="s" icon="edit" />
+//                             </Button>
+//                         </Tooltip>
+//                         <Text mr="auto">{uploader.name}</Text>
+//                         <Text ml={2} mr={2}>
+//                             &lt;
+//                             <Link isExternal href={`mailto:${uploader.email}`}>
+//                                 {uploader.email}
+//                             </Link>
+//                             &gt;
+//                         </Text>
+//                     </>
+//                 ) : (
+//                     <HStack alignItems="flex-start" mr="auto">
+//                         <Tooltip label="Save changes">
+//                             <Button
+//                                 size="xs"
+//                                 aria-label="Save changes"
+//                                 onClick={async () => {
+//                                     try {
+//                                         await updateUploader({
+//                                             variables: {
+//                                                 id: uploader.id,
+//                                                 update: {
+//                                                     email: newEmail,
+//                                                     name: newName,
+//                                                 },
+//                                             },
+//                                         });
+
+//                                         setIsEditing(false);
+//                                     } catch (e) {
+//                                         toast({
+//                                             title: "Error updating uploader",
+//                                             description: e.message ?? e.toString(),
+//                                             isClosable: true,
+//                                             duration: 10000,
+//                                             position: "bottom",
+//                                             status: "error",
+//                                         });
+//                                     }
+//                                 }}
+//                                 colorScheme="purple"
+//                                 isDisabled={newName === "" || newEmail === "" || !newEmailIsValid}
+//                                 isLoading={updateUploaderResponse.loading}
+//                             >
+//                                 <FAIcon iconStyle="s" icon="save" />
+//                             </Button>
+//                         </Tooltip>
+//                         <Tooltip label="Discard changes">
+//                             <Button
+//                                 size="xs"
+//                                 aria-label="Discard changes"
+//                                 onClick={() => {
+//                                     setNewName(uploader.name);
+//                                     setNewEmail(uploader.email);
+//                                     setIsEditing(false);
+//                                 }}
+//                                 mr={2}
+//                                 colorScheme="yellow"
+//                                 isLoading={updateUploaderResponse.loading}
+//                             >
+//                                 <FAIcon iconStyle="s" icon="ban" />
+//                             </Button>
+//                         </Tooltip>
+//                         <Input
+//                             value={newName}
+//                             size="sm"
+//                             minW={70}
+//                             onChange={(ev) => {
+//                                 setNewName(ev.target.value);
+//                             }}
+//                         />
+//                         <Input
+//                             type="email"
+//                             value={newEmail}
+//                             size="sm"
+//                             minW={70}
+//                             onChange={(ev) => {
+//                                 setNewEmail(ev.target.value);
+//                                 setNewEmailIsValid(ev.target.validity.valid);
+//                             }}
+//                         />
+//                     </HStack>
+//                 )}
+//                 <Tooltip label="Delete uploader">
+//                     <Button
+//                         ml={2}
+//                         size="xs"
+//                         colorScheme="red"
+//                         aria-label="Delete uploader"
+//                         isLoading={deleteUploadersResponse.loading}
+//                         onClick={async () => {
+//                             try {
+//                                 await deleteUploaders({
+//                                     variables: {
+//                                         ids: [uploader.id],
+//                                     },
+//                                 });
+//                             } catch (e) {
+//                                 toast({
+//                                     title: "Error deleting uploader",
+//                                     description: e.message ?? e.toString(),
+//                                     isClosable: true,
+//                                     duration: 10000,
+//                                     position: "bottom",
+//                                     status: "error",
+//                                 });
+//                             }
+//                         }}
+//                     >
+//                         <FAIcon iconStyle="s" icon="trash-alt" />
+//                     </Button>
+//                 </Tooltip>
+//             </Flex>
+//         </ListItem>
+//     );
+// }

--- a/frontend/src/aspects/Conference/Manage/Content/v2/Item/EditItemPeople.tsx
+++ b/frontend/src/aspects/Conference/Manage/Content/v2/Item/EditItemPeople.tsx
@@ -81,7 +81,7 @@ export function EditItemPeoplePanel({ itemId }: { itemId: string }): JSX.Element
 
 gql`
     query ManageContent_SelectProgramPeople($conferenceId: uuid!) {
-        collection_ProgramPerson(where: { conferenceId: { _eq: $conferenceId } }) {
+        collection_ProgramPersonWithAccessToken(where: { conferenceId: { _eq: $conferenceId } }) {
             ...ManageContent_ProgramPerson
         }
     }
@@ -143,10 +143,10 @@ function AddItemPersonBody({
 
     const sortedPeople = useMemo(
         () =>
-            peopleResponse.data?.collection_ProgramPerson
+            peopleResponse.data?.collection_ProgramPersonWithAccessToken
                 .filter((person) => !existingPeopleIds.includes(person.id))
-                .sort((x, y) => x.name.localeCompare(y.name)),
-        [existingPeopleIds, peopleResponse.data?.collection_ProgramPerson]
+                .sort((x, y) => maybeCompare(x.name, y.name, (a, b) => a.localeCompare(b))),
+        [existingPeopleIds, peopleResponse.data?.collection_ProgramPersonWithAccessToken]
     );
 
     const toast = useToast();
@@ -297,7 +297,7 @@ function ItemPersonsList({
                             ? 1
                             : x.roleName.toUpperCase().localeCompare(y.roleName.toUpperCase()),
                     (x, y) => maybeCompare(x.priority, y.priority, (a, b) => a - b),
-                    (x, y) => x.person.name.localeCompare(y.person.name),
+                    (x, y) => maybeCompare(x.person?.name, y.person?.name, (a, b) => a.localeCompare(b)),
                 ],
                 itemPeople
             ),
@@ -499,7 +499,7 @@ function ItemPersonsList({
                                 </ButtonGroup>
                                 <Tooltip
                                     label={
-                                        itemProgramPerson.person.registrantId
+                                        itemProgramPerson.person?.registrantId
                                             ? "Person is linked to registrant."
                                             : "Person is not linked to registrant."
                                     }
@@ -507,11 +507,11 @@ function ItemPersonsList({
                                     <FAIcon
                                         iconStyle="s"
                                         icon={
-                                            itemProgramPerson.person.registrantId
+                                            itemProgramPerson.person?.registrantId
                                                 ? "check-circle"
                                                 : "exclamation-triangle"
                                         }
-                                        color={itemProgramPerson.person.registrantId ? "purple.400" : "yellow.400"}
+                                        color={itemProgramPerson.person?.registrantId ? "purple.400" : "yellow.400"}
                                     />
                                 </Tooltip>
                                 <Flex
@@ -520,10 +520,10 @@ function ItemPersonsList({
                                     justifyContent="flex-start"
                                     alignItems="flex-start"
                                 >
-                                    <chakra.span mx={2}>{itemProgramPerson.person.name}</chakra.span>
+                                    <chakra.span mx={2}>{itemProgramPerson.person?.name}</chakra.span>
                                     <chakra.span ml={["0", "0", "auto"]} mr={2}>
                                         &lt;
-                                        {itemProgramPerson.person.email?.length
+                                        {itemProgramPerson.person?.email?.length
                                             ? itemProgramPerson.person.email
                                             : "No email"}
                                         &gt;

--- a/frontend/src/aspects/Conference/Manage/Email/ConfigureEmailTemplates.tsx
+++ b/frontend/src/aspects/Conference/Manage/Email/ConfigureEmailTemplates.tsx
@@ -15,6 +15,7 @@ import {
     Spinner,
     Text,
     Textarea,
+    VStack,
 } from "@chakra-ui/react";
 import {
     EmailTemplate_BaseConfig,
@@ -148,39 +149,49 @@ export function ConfigureEmailTemplatesInner({
 
     return (
         <>
-            {updateConferenceConfigurationResponse.loading ? <Spinner /> : undefined}
-            <Accordion minW="50vw" allowToggle allowMultiple>
+            <Box minH="3ex" py={4}>
+                {updateConferenceConfigurationResponse.loading ? (
+                    <HStack spacing={2}>
+                        <Text>Saving</Text> <Spinner />
+                    </HStack>
+                ) : updateConferenceConfigurationResponse.data ? (
+                    updateConferenceConfigurationResponse.error ? (
+                        <Text>Error saving changes.</Text>
+                    ) : (
+                        <Text>Changes saved.</Text>
+                    )
+                ) : undefined}
+            </Box>
+            <Accordion w="100%" allowToggle allowMultiple reduceMotion>
                 <AccordionItem>
                     <AccordionButton>
-                        <Box flex="1" textAlign="left">
-                            <Heading as="h3" size="sm">
-                                Submission request email
-                            </Heading>
-                        </Box>
-                        <AccordionIcon />
+                        <AccordionIcon mr={2} />
+                        <Heading as="h3" size="sm" textAlign="left" fontWeight="normal">
+                            Submission request email
+                        </Heading>
                     </AccordionButton>
                     <AccordionPanel>
                         <EmailTemplateForm
                             templateConfig={emailTemplateConfig_SubmissionRequest}
                             templateDefaults={EMAIL_TEMPLATE_SUBMISSION_REQUEST}
                             update={update(Conference_ConfigurationKey_Enum.EmailTemplateSubmissionRequest)}
+                            description="This email is sent to people when requesting submissions. You can also customise this email before each time you send out requests."
                         />
                     </AccordionPanel>
                 </AccordionItem>
                 <AccordionItem>
                     <AccordionButton>
-                        <Box flex="1" textAlign="left">
-                            <Heading as="h3" size="sm">
-                                Subtitles notification email
-                            </Heading>
-                        </Box>
-                        <AccordionIcon />
+                        <AccordionIcon mr={2} />
+                        <Heading as="h3" size="sm" textAlign="left" fontWeight="normal">
+                            Subtitles notification email
+                        </Heading>
                     </AccordionButton>
                     <AccordionPanel>
                         <EmailTemplateForm
                             templateConfig={emailTemplateConfig_SubtitlesGenerated}
                             templateDefaults={EMAIL_TEMPLATE_SUBTITLES_GENERATED}
                             update={update(Conference_ConfigurationKey_Enum.EmailTemplateSubtitlesGenerated)}
+                            description="This email is sent to people automatically when subtitles have been generated for one of their items."
                         />
                     </AccordionPanel>
                 </AccordionItem>
@@ -193,10 +204,12 @@ function EmailTemplateForm({
     templateConfig,
     templateDefaults,
     update,
+    description,
 }: {
     templateConfig: EmailTemplate_BaseConfig | null;
     templateDefaults: EmailTemplate_Defaults;
     update: (_templateConfig: EmailTemplate_BaseConfig) => void;
+    description: string;
 }) {
     const [subjectTemplate, setSubjectTemplate] = useState<string | null>(null);
     const [htmlBodyTemplate, setHtmlBodyTemplate] = useState<string | null>(null);
@@ -219,22 +232,22 @@ function EmailTemplateForm({
     }, [templateConfig?.htmlBodyTemplate]);
 
     return (
-        <>
-            <HStack justifyContent="space-between" alignItems="center" my={4}>
-                <Text>
-                    This email is sent to uploaders automatically once subtitles have been generated for one of their
-                    items.
-                </Text>
-                {templateConfig?.htmlBodyTemplate || templateConfig?.subjectTemplate ? (
-                    <Button
-                        size="sm"
-                        aria-label="Reset email text and subject line to defaults"
-                        onClick={() => update({ subjectTemplate: null, htmlBodyTemplate: null })}
-                    >
-                        Reset to default
-                    </Button>
-                ) : undefined}
-            </HStack>
+        <VStack spacing={4} alignItems="flex-start">
+            <Text>{description}</Text>
+            {templateDefaults?.htmlBodyTemplate || templateDefaults?.subjectTemplate ? (
+                <Button
+                    colorScheme="purple"
+                    size="sm"
+                    aria-label="Reset email text and subject line to defaults"
+                    onClick={() => update({ subjectTemplate: null, htmlBodyTemplate: null })}
+                    isDisabled={
+                        templateDefaults.htmlBodyTemplate === htmlBodyTemplateValue &&
+                        templateDefaults.subjectTemplate === subjectTemplateValue
+                    }
+                >
+                    Reset to default
+                </Button>
+            ) : undefined}
             <FormControl>
                 <FormLabel>Subject</FormLabel>
                 <Input
@@ -268,6 +281,6 @@ function EmailTemplateForm({
                     }}
                 />
             </FormControl>
-        </>
+        </VStack>
     );
 }

--- a/frontend/src/aspects/Conference/Manage/Email/ManageEmail.tsx
+++ b/frontend/src/aspects/Conference/Manage/Email/ManageEmail.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading } from "@chakra-ui/react";
+import { Container, Heading, VStack } from "@chakra-ui/react";
 import React from "react";
 import { Permissions_Permission_Enum } from "../../../../generated/graphql";
 import PageNotFound from "../../../Errors/PageNotFound";
@@ -9,23 +9,25 @@ import { ConfigureEmailTemplates } from "./ConfigureEmailTemplates";
 
 export default function ManageEmail(): JSX.Element {
     const conference = useConference();
-    const title = useTitle(`Manage email settings for ${conference.shortName}`);
+    const title = useTitle(`Manage email templates for ${conference.shortName}`);
 
     return (
         <RequireAtLeastOnePermissionWrapper
             permissions={[Permissions_Permission_Enum.ConferenceManageContent]}
             componentIfDenied={<PageNotFound />}
         >
-            <Box w="100%">
-                {title}
-                <Heading as="h1" size="xl">
-                    Manage {conference.shortName}
-                </Heading>
-                <Heading id="page-heading" as="h2" size="lg" fontStyle="italic">
-                    Email
-                </Heading>
-                <ConfigureEmailTemplates />
-            </Box>
+            {title}
+            <Container maxW="container.lg">
+                <VStack spacing={4} alignItems="flex-start" mt={6}>
+                    <Heading as="h1" size="xl">
+                        Email Templates
+                    </Heading>
+                    <Heading id="page-heading" as="h2" size="md">
+                        Manage {conference.shortName}
+                    </Heading>
+                    <ConfigureEmailTemplates />
+                </VStack>
+            </Container>
         </RequireAtLeastOnePermissionWrapper>
     );
 }

--- a/frontend/src/aspects/Conference/Manage/ManageProgramPeople.tsx
+++ b/frontend/src/aspects/Conference/Manage/ManageProgramPeople.tsx
@@ -22,8 +22,6 @@ import Papa from "papaparse";
 import React, { LegacyRef, useCallback, useMemo, useRef } from "react";
 import { v4 as uuidv4 } from "uuid";
 import {
-    ManageProgramPeople_ProgramPersonFragment,
-    ManageProgramPeople_ProgramPersonFragmentDoc,
     ManageProgramPeople_ProgramPersonWithAccessTokenFragment,
     ManageProgramPeople_ProgramPersonWithAccessTokenFragmentDoc,
     ManageProgramPeople_RegistrantFragment,
@@ -71,16 +69,6 @@ gql`
         }
     }
 
-    fragment ManageProgramPeople_ProgramPerson on collection_ProgramPerson {
-        id
-        conferenceId
-        name
-        affiliation
-        email
-        originatingDataId
-        registrantId
-    }
-
     fragment ManageProgramPeople_ProgramPersonWithAccessToken on collection_ProgramPersonWithAccessToken {
         id
         conferenceId
@@ -104,14 +92,14 @@ gql`
         }
     }
 
-    mutation ManageProgramPeople_InsertProgramPerson($person: collection_ProgramPerson_insert_input!) {
-        insert_collection_ProgramPerson_one(object: $person) {
-            ...ManageProgramPeople_ProgramPerson
+    mutation ManageProgramPeople_InsertProgramPerson($person: collection_ProgramPersonWithAccessToken_insert_input!) {
+        insert_collection_ProgramPersonWithAccessToken_one(object: $person) {
+            ...ManageProgramPeople_ProgramPersonWithAccessToken
         }
     }
 
     mutation ManageProgramPeople_DeleteProgramPersons($ids: [uuid!] = []) {
-        delete_collection_ProgramPerson(where: { id: { _in: $ids } }) {
+        delete_collection_ProgramPersonWithAccessToken(where: { id: { _in: $ids } }) {
             returning {
                 id
             }
@@ -125,20 +113,16 @@ gql`
         $email: String
         $registrantId: uuid
     ) {
-        update_collection_ProgramPerson_by_pk(
-            pk_columns: { id: $id }
+        update_collection_ProgramPersonWithAccessToken(
+            where: { id: { _eq: $id } }
             _set: { name: $name, affiliation: $affiliation, email: $email, registrantId: $registrantId }
         ) {
-            ...ManageProgramPeople_ProgramPerson
+            returning {
+                ...ManageProgramPeople_ProgramPersonWithAccessToken
+            }
         }
     }
 `;
-
-type ManageProgramPeople_ProgramPersonWithMaybeAccessToken = Omit<
-    ManageProgramPeople_ProgramPersonFragment &
-        Partial<Pick<ManageProgramPeople_ProgramPersonWithAccessTokenFragment, "accessToken">>,
-    "__typename"
->;
 
 export default function ManageProgramPeople(): JSX.Element {
     const conference = useConference();
@@ -169,7 +153,7 @@ export default function ManageProgramPeople(): JSX.Element {
         /* EMPTY */
     });
 
-    const row: RowSpecification<ManageProgramPeople_ProgramPersonWithMaybeAccessToken> = useMemo(
+    const row: RowSpecification<ManageProgramPeople_ProgramPersonWithAccessTokenFragment> = useMemo(
         () => ({
             getKey: (record) => record.id,
             canSelect: (_record) => true,
@@ -187,7 +171,7 @@ export default function ManageProgramPeople(): JSX.Element {
         []
     );
 
-    const columns: ColumnSpecification<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>[] = useMemo(
+    const columns: ColumnSpecification<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>[] = useMemo(
         () => [
             {
                 id: "name",
@@ -196,7 +180,7 @@ export default function ManageProgramPeople(): JSX.Element {
                     isInCreate,
                     onClick,
                     sortDir,
-                }: ColumnHeaderProps<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>) {
+                }: ColumnHeaderProps<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>) {
                     return isInCreate ? (
                         <FormLabel>Name</FormLabel>
                     ) : (
@@ -209,11 +193,14 @@ export default function ManageProgramPeople(): JSX.Element {
                 set: (record, value: string | undefined) => {
                     record.name = value;
                 },
-                filterFn: (rows: Array<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>, filterValue: string) => {
+                filterFn: (
+                    rows: Array<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>,
+                    filterValue: string
+                ) => {
                     if (filterValue === "") {
                         return rows.filter((row) => (row.name ?? "") === "");
                     } else {
-                        return rows.filter((row) => row.name.toLowerCase().includes(filterValue.toLowerCase()));
+                        return rows.filter((row) => row.name?.toLowerCase().includes(filterValue.toLowerCase()));
                     }
                 },
                 filterEl: TextColumnFilter,
@@ -224,7 +211,7 @@ export default function ManageProgramPeople(): JSX.Element {
                     onChange,
                     onBlur,
                     ref,
-                }: CellProps<Partial<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>, string | undefined>) {
+                }: CellProps<Partial<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>, string | undefined>) {
                     const { onCopy, hasCopied } = useClipboard(value ?? "");
                     return (
                         <Flex alignItems="center">
@@ -252,7 +239,7 @@ export default function ManageProgramPeople(): JSX.Element {
                     isInCreate,
                     onClick,
                     sortDir,
-                }: ColumnHeaderProps<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>) {
+                }: ColumnHeaderProps<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>) {
                     return isInCreate ? (
                         <FormLabel>Affiliation</FormLabel>
                     ) : (
@@ -265,7 +252,10 @@ export default function ManageProgramPeople(): JSX.Element {
                 set: (record, value: string | undefined) => {
                     record.affiliation = value;
                 },
-                filterFn: (rows: Array<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>, filterValue: string) => {
+                filterFn: (
+                    rows: Array<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>,
+                    filterValue: string
+                ) => {
                     if (filterValue === "") {
                         return rows.filter((row) => (row.affiliation ?? "") === "");
                     } else {
@@ -284,7 +274,7 @@ export default function ManageProgramPeople(): JSX.Element {
                     onChange,
                     onBlur,
                     ref,
-                }: CellProps<Partial<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>, string | undefined>) {
+                }: CellProps<Partial<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>, string | undefined>) {
                     const { onCopy, hasCopied } = useClipboard(value ?? "");
                     return (
                         <Flex alignItems="center">
@@ -311,7 +301,7 @@ export default function ManageProgramPeople(): JSX.Element {
                     isInCreate,
                     onClick,
                     sortDir,
-                }: ColumnHeaderProps<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>) {
+                }: ColumnHeaderProps<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>) {
                     return isInCreate ? (
                         <FormLabel>Email</FormLabel>
                     ) : (
@@ -324,7 +314,10 @@ export default function ManageProgramPeople(): JSX.Element {
                 set: (record, value: string | undefined) => {
                     record.email = value;
                 },
-                filterFn: (rows: Array<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>, filterValue: string) => {
+                filterFn: (
+                    rows: Array<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>,
+                    filterValue: string
+                ) => {
                     if (filterValue === "") {
                         return rows.filter((row) => (row.email ?? "") === "");
                     } else {
@@ -341,7 +334,7 @@ export default function ManageProgramPeople(): JSX.Element {
                     onChange,
                     onBlur,
                     ref,
-                }: CellProps<Partial<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>, string | undefined>) {
+                }: CellProps<Partial<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>, string | undefined>) {
                     const { onCopy, hasCopied } = useClipboard(value ?? "");
                     return (
                         <Flex alignItems="center">
@@ -368,7 +361,7 @@ export default function ManageProgramPeople(): JSX.Element {
                     isInCreate,
                     onClick,
                     sortDir,
-                }: ColumnHeaderProps<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>) {
+                }: ColumnHeaderProps<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>) {
                     return isInCreate ? undefined : (
                         <Button size="xs" onClick={onClick}>
                             Access Token{sortDir !== null ? ` ${sortDir}` : undefined}
@@ -379,7 +372,10 @@ export default function ManageProgramPeople(): JSX.Element {
                 set: (record, value: string | undefined) => {
                     record.accessToken = value;
                 },
-                filterFn: (rows: Array<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>, filterValue: string) => {
+                filterFn: (
+                    rows: Array<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>,
+                    filterValue: string
+                ) => {
                     if (filterValue === "") {
                         return rows.filter((row) => (row.accessToken ?? "") === "");
                     } else {
@@ -395,7 +391,7 @@ export default function ManageProgramPeople(): JSX.Element {
                     maybeCompare(x, y, (a, b) => a.localeCompare(b)),
                 cell: function ProgramPersonCell({
                     value,
-                }: CellProps<Partial<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>, string | undefined>) {
+                }: CellProps<Partial<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>, string | undefined>) {
                     const { onCopy, hasCopied } = useClipboard(`${window.origin}/submissions/${value}` ?? "");
                     return (
                         <Flex alignItems="center">
@@ -416,7 +412,7 @@ export default function ManageProgramPeople(): JSX.Element {
                     isInCreate,
                     onClick,
                     sortDir,
-                }: ColumnHeaderProps<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>) {
+                }: ColumnHeaderProps<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>) {
                     return isInCreate ? (
                         <FormLabel>Registrant</FormLabel>
                     ) : (
@@ -429,7 +425,10 @@ export default function ManageProgramPeople(): JSX.Element {
                 set: (record, value: ManageProgramPeople_RegistrantFragment | undefined) => {
                     record.registrantId = value?.id;
                 },
-                filterFn: (rows: Array<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>, filterValue: string) => {
+                filterFn: (
+                    rows: Array<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>,
+                    filterValue: string
+                ) => {
                     if (filterValue === "") {
                         return rows.filter((row) => !row.registrantId);
                     } else {
@@ -462,7 +461,7 @@ export default function ManageProgramPeople(): JSX.Element {
                     onBlur,
                     ref,
                 }: CellProps<
-                    Partial<ManageProgramPeople_ProgramPersonWithMaybeAccessToken>,
+                    Partial<ManageProgramPeople_ProgramPersonWithAccessTokenFragment>,
                     ManageProgramPeople_RegistrantFragment | undefined
                 >) {
                     return (
@@ -503,7 +502,7 @@ export default function ManageProgramPeople(): JSX.Element {
     const [deleteProgramPersons, deleteProgramPersonsResponse] = useManageProgramPeople_DeleteProgramPersonsMutation();
     const [updateProgramPerson, updateProgramPersonResponse] = useManageProgramPeople_UpdateProgramPersonMutation();
 
-    const insert: Insert<ManageProgramPeople_ProgramPersonFragment> = useMemo(
+    const insert: Insert<ManageProgramPeople_ProgramPersonWithAccessTokenFragment> = useMemo(
         () => ({
             ongoing: insertProgramPersonResponse.loading,
             generateDefaults: () => {
@@ -513,7 +512,8 @@ export default function ManageProgramPeople(): JSX.Element {
                     conferenceId: conference.id,
                 };
             },
-            makeWhole: (d) => (d.name?.length ? (d as ManageProgramPeople_ProgramPersonFragment) : undefined),
+            makeWhole: (d) =>
+                d.name?.length ? (d as ManageProgramPeople_ProgramPersonWithAccessTokenFragment) : undefined,
             start: (record) => {
                 insertProgramPerson({
                     variables: {
@@ -527,17 +527,12 @@ export default function ManageProgramPeople(): JSX.Element {
                         },
                     },
                     update: (cache, { data: _data }) => {
-                        if (_data?.insert_collection_ProgramPerson_one) {
-                            const data = _data.insert_collection_ProgramPerson_one;
+                        if (_data?.insert_collection_ProgramPersonWithAccessToken_one) {
+                            const data = _data.insert_collection_ProgramPersonWithAccessToken_one;
                             cache.writeFragment({
                                 data,
                                 fragment: ManageProgramPeople_ProgramPersonWithAccessTokenFragmentDoc,
                                 fragmentName: "ManageProgramPeople_ProgramPersonWithAccessToken",
-                            });
-                            cache.writeFragment({
-                                data,
-                                fragment: ManageProgramPeople_ProgramPersonFragmentDoc,
-                                fragmentName: "ManageProgramPeople_ProgramPerson",
                             });
                         }
                     },
@@ -558,17 +553,12 @@ export default function ManageProgramPeople(): JSX.Element {
                     email: record.email !== "" ? record.email ?? null : null,
                 },
                 update: (cache, { data: _data }) => {
-                    if (_data?.update_collection_ProgramPerson_by_pk) {
-                        const data = _data.update_collection_ProgramPerson_by_pk;
+                    if (_data?.update_collection_ProgramPersonWithAccessToken?.returning.length) {
+                        const data = _data.update_collection_ProgramPersonWithAccessToken.returning[0];
                         cache.writeFragment({
                             data,
                             fragment: ManageProgramPeople_ProgramPersonWithAccessTokenFragmentDoc,
                             fragmentName: "ManageProgramPeople_ProgramPersonWithAccessToken",
-                        });
-                        cache.writeFragment({
-                            data,
-                            fragment: ManageProgramPeople_ProgramPersonFragmentDoc,
-                            fragmentName: "ManageProgramPeople_ProgramPerson",
                         });
                     }
                 },
@@ -577,7 +567,7 @@ export default function ManageProgramPeople(): JSX.Element {
         [updateProgramPerson]
     );
 
-    const update: Update<ManageProgramPeople_ProgramPersonWithMaybeAccessToken> = useMemo(
+    const update: Update<ManageProgramPeople_ProgramPersonWithAccessTokenFragment> = useMemo(
         () => ({
             ongoing: updateProgramPersonResponse.loading,
             start: startUpdate,
@@ -585,7 +575,7 @@ export default function ManageProgramPeople(): JSX.Element {
         [updateProgramPersonResponse.loading, startUpdate]
     );
 
-    const deleteP: Delete<ManageProgramPeople_ProgramPersonWithMaybeAccessToken> = useMemo(
+    const deleteP: Delete<ManageProgramPeople_ProgramPersonWithAccessTokenFragment> = useMemo(
         () => ({
             ongoing: deleteProgramPersonsResponse.loading,
             start: (keys) => {
@@ -594,18 +584,16 @@ export default function ManageProgramPeople(): JSX.Element {
                         ids: keys,
                     },
                     update: (cache, { data: _data }) => {
-                        if (_data?.delete_collection_ProgramPerson) {
-                            const data = _data.delete_collection_ProgramPerson;
+                        if (_data?.delete_collection_ProgramPersonWithAccessToken) {
+                            const data = _data.delete_collection_ProgramPersonWithAccessToken;
                             const deletedIds = data.returning.map((x) => x.id);
                             cache.modify({
                                 fields: {
-                                    collection_ProgramPerson(existingRefs: Reference[] = [], { readField }) {
+                                    collection_ProgramPersonWithAccessToken(
+                                        existingRefs: Reference[] = [],
+                                        { readField }
+                                    ) {
                                         deletedIds.forEach((x) => {
-                                            cache.evict({
-                                                id: x.id,
-                                                fieldName: "ManageProgramPeople_ProgramPerson",
-                                                broadcast: true,
-                                            });
                                             cache.evict({
                                                 id: x.id,
                                                 fieldName: "ManageProgramPeople_ProgramPersonWithAccessToken",
@@ -738,9 +726,9 @@ export default function ManageProgramPeople(): JSX.Element {
                 render: function ExportPeople({
                     selectedData,
                 }: {
-                    selectedData: ManageProgramPeople_ProgramPersonWithMaybeAccessToken[];
+                    selectedData: ManageProgramPeople_ProgramPersonWithAccessTokenFragment[];
                 }) {
-                    function doExport(dataToExport: ManageProgramPeople_ProgramPersonWithMaybeAccessToken[]) {
+                    function doExport(dataToExport: ManageProgramPeople_ProgramPersonWithAccessTokenFragment[]) {
                         const csvText = Papa.unparse(
                             dataToExport.map((person) => ({
                                 "Conference Id": person.conferenceId,
@@ -798,18 +786,14 @@ export default function ManageProgramPeople(): JSX.Element {
                                 <MenuList>
                                     <MenuItem
                                         onClick={() => {
-                                            doExport(data as ManageProgramPeople_ProgramPersonWithMaybeAccessToken[]);
+                                            doExport(data);
                                         }}
                                     >
                                         All
                                     </MenuItem>
                                     <MenuItem
                                         onClick={() => {
-                                            doExport(
-                                                data.filter(
-                                                    (a) => !!a.email
-                                                ) as ManageProgramPeople_ProgramPersonWithMaybeAccessToken[]
-                                            );
+                                            doExport(data.filter((a) => !!a.email));
                                         }}
                                     >
                                         <FAIcon iconStyle="s" icon="envelope" w="1em" textAlign="center" mr={2} />
@@ -817,11 +801,7 @@ export default function ManageProgramPeople(): JSX.Element {
                                     </MenuItem>
                                     <MenuItem
                                         onClick={() => {
-                                            doExport(
-                                                data.filter(
-                                                    (a) => !a.email
-                                                ) as ManageProgramPeople_ProgramPersonWithMaybeAccessToken[]
-                                            );
+                                            doExport(data.filter((a) => !a.email));
                                         }}
                                     >
                                         <FAIcon iconStyle="r" icon="envelope" w="1em" textAlign="center" mr={2} />
@@ -829,11 +809,7 @@ export default function ManageProgramPeople(): JSX.Element {
                                     </MenuItem>
                                     <MenuItem
                                         onClick={() => {
-                                            doExport(
-                                                data.filter(
-                                                    (a) => a.registrantId
-                                                ) as ManageProgramPeople_ProgramPersonWithMaybeAccessToken[]
-                                            );
+                                            doExport(data.filter((a) => a.registrantId));
                                         }}
                                     >
                                         <FAIcon iconStyle="s" icon="link" w="1em" textAlign="center" mr={2} />
@@ -841,11 +817,7 @@ export default function ManageProgramPeople(): JSX.Element {
                                     </MenuItem>
                                     <MenuItem
                                         onClick={() => {
-                                            doExport(
-                                                data.filter(
-                                                    (a) => !a.registrantId
-                                                ) as ManageProgramPeople_ProgramPersonWithMaybeAccessToken[]
-                                            );
+                                            doExport(data.filter((a) => !a.registrantId));
                                         }}
                                     >
                                         <FAIcon iconStyle="s" icon="unlink" w="1em" textAlign="center" mr={2} />
@@ -903,9 +875,7 @@ export default function ManageProgramPeople(): JSX.Element {
             <CRUDTable
                 data={
                     !loadingAllProgramPersons &&
-                    (allProgramPersons?.collection_ProgramPersonWithAccessToken
-                        ? (data as ManageProgramPeople_ProgramPersonWithMaybeAccessToken[])
-                        : null)
+                    (allProgramPersons?.collection_ProgramPersonWithAccessToken ? data : null)
                 }
                 tableUniqueName="ManageConferenceProgramPeople"
                 row={row}

--- a/frontend/src/aspects/Conference/Manage/ManagerLanding.tsx
+++ b/frontend/src/aspects/Conference/Manage/ManagerLanding.tsx
@@ -20,7 +20,7 @@ export default function ManagerLandingPage(): JSX.Element {
     return (
         <>
             {title}
-            <Heading as="h1" id="page-heading">
+            <Heading as="h1" id="page-heading" mt={4}>
                 Manage {conference.shortName}
             </Heading>
             <Flex

--- a/frontend/src/aspects/Conference/NewConferenceForm.tsx
+++ b/frontend/src/aspects/Conference/NewConferenceForm.tsx
@@ -271,9 +271,7 @@ gql`
                 title: "Landing page"
             }
         ) {
-            returning {
-                ...ItemElements_ItemData
-            }
+            affected_rows
         }
     }
 `;

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -6483,6 +6483,7 @@ export type Collection_ProgramPerson = {
   /** An object relationship */
   readonly registrant?: Maybe<Registrant_Registrant>;
   readonly registrantId?: Maybe<Scalars['uuid']>;
+  readonly submissionRequestsSentCount: Scalars['Int'];
 };
 
 
@@ -6717,6 +6718,7 @@ export type Collection_ProgramPersonWithAccessToken = {
   /** An object relationship */
   readonly registrant?: Maybe<Registrant_Registrant>;
   readonly registrantId?: Maybe<Scalars['uuid']>;
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 
@@ -6749,9 +6751,17 @@ export type Collection_ProgramPersonWithAccessToken_Aggregate = {
 /** aggregate fields of "collection.ProgramPersonWithAccessToken" */
 export type Collection_ProgramPersonWithAccessToken_Aggregate_Fields = {
   readonly __typename?: 'collection_ProgramPersonWithAccessToken_aggregate_fields';
+  readonly avg?: Maybe<Collection_ProgramPersonWithAccessToken_Avg_Fields>;
   readonly count: Scalars['Int'];
   readonly max?: Maybe<Collection_ProgramPersonWithAccessToken_Max_Fields>;
   readonly min?: Maybe<Collection_ProgramPersonWithAccessToken_Min_Fields>;
+  readonly stddev?: Maybe<Collection_ProgramPersonWithAccessToken_Stddev_Fields>;
+  readonly stddev_pop?: Maybe<Collection_ProgramPersonWithAccessToken_Stddev_Pop_Fields>;
+  readonly stddev_samp?: Maybe<Collection_ProgramPersonWithAccessToken_Stddev_Samp_Fields>;
+  readonly sum?: Maybe<Collection_ProgramPersonWithAccessToken_Sum_Fields>;
+  readonly var_pop?: Maybe<Collection_ProgramPersonWithAccessToken_Var_Pop_Fields>;
+  readonly var_samp?: Maybe<Collection_ProgramPersonWithAccessToken_Var_Samp_Fields>;
+  readonly variance?: Maybe<Collection_ProgramPersonWithAccessToken_Variance_Fields>;
 };
 
 
@@ -6759,6 +6769,12 @@ export type Collection_ProgramPersonWithAccessToken_Aggregate_Fields = {
 export type Collection_ProgramPersonWithAccessToken_Aggregate_FieldsCountArgs = {
   columns?: Maybe<ReadonlyArray<Collection_ProgramPersonWithAccessToken_Select_Column>>;
   distinct?: Maybe<Scalars['Boolean']>;
+};
+
+/** aggregate avg on columns */
+export type Collection_ProgramPersonWithAccessToken_Avg_Fields = {
+  readonly __typename?: 'collection_ProgramPersonWithAccessToken_avg_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
 };
 
 /** Boolean expression to filter rows from the table "collection.ProgramPersonWithAccessToken". All fields are combined with a logical 'AND'. */
@@ -6777,6 +6793,12 @@ export type Collection_ProgramPersonWithAccessToken_Bool_Exp = {
   readonly originatingDataId?: Maybe<Uuid_Comparison_Exp>;
   readonly registrant?: Maybe<Registrant_Registrant_Bool_Exp>;
   readonly registrantId?: Maybe<Uuid_Comparison_Exp>;
+  readonly submissionRequestsSentCount?: Maybe<Int_Comparison_Exp>;
+};
+
+/** input type for incrementing numeric columns in table "collection.ProgramPersonWithAccessToken" */
+export type Collection_ProgramPersonWithAccessToken_Inc_Input = {
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "collection.ProgramPersonWithAccessToken" */
@@ -6792,6 +6814,7 @@ export type Collection_ProgramPersonWithAccessToken_Insert_Input = {
   readonly originatingDataId?: Maybe<Scalars['uuid']>;
   readonly registrant?: Maybe<Registrant_Registrant_Obj_Rel_Insert_Input>;
   readonly registrantId?: Maybe<Scalars['uuid']>;
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -6805,6 +6828,7 @@ export type Collection_ProgramPersonWithAccessToken_Max_Fields = {
   readonly name?: Maybe<Scalars['String']>;
   readonly originatingDataId?: Maybe<Scalars['uuid']>;
   readonly registrantId?: Maybe<Scalars['uuid']>;
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate min on columns */
@@ -6818,6 +6842,7 @@ export type Collection_ProgramPersonWithAccessToken_Min_Fields = {
   readonly name?: Maybe<Scalars['String']>;
   readonly originatingDataId?: Maybe<Scalars['uuid']>;
   readonly registrantId?: Maybe<Scalars['uuid']>;
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** response of any mutation on the table "collection.ProgramPersonWithAccessToken" */
@@ -6827,6 +6852,11 @@ export type Collection_ProgramPersonWithAccessToken_Mutation_Response = {
   readonly affected_rows: Scalars['Int'];
   /** data from the rows affected by the mutation */
   readonly returning: ReadonlyArray<Collection_ProgramPersonWithAccessToken>;
+};
+
+/** input type for inserting object relation for remote table "collection.ProgramPersonWithAccessToken" */
+export type Collection_ProgramPersonWithAccessToken_Obj_Rel_Insert_Input = {
+  readonly data: Collection_ProgramPersonWithAccessToken_Insert_Input;
 };
 
 /** Ordering options when selecting data from "collection.ProgramPersonWithAccessToken". */
@@ -6842,6 +6872,7 @@ export type Collection_ProgramPersonWithAccessToken_Order_By = {
   readonly originatingDataId?: Maybe<Order_By>;
   readonly registrant?: Maybe<Registrant_Registrant_Order_By>;
   readonly registrantId?: Maybe<Order_By>;
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** select columns of table "collection.ProgramPersonWithAccessToken" */
@@ -6861,7 +6892,9 @@ export enum Collection_ProgramPersonWithAccessToken_Select_Column {
   /** column name */
   OriginatingDataId = 'originatingDataId',
   /** column name */
-  RegistrantId = 'registrantId'
+  RegistrantId = 'registrantId',
+  /** column name */
+  SubmissionRequestsSentCount = 'submissionRequestsSentCount'
 }
 
 /** input type for updating data in table "collection.ProgramPersonWithAccessToken" */
@@ -6874,6 +6907,49 @@ export type Collection_ProgramPersonWithAccessToken_Set_Input = {
   readonly name?: Maybe<Scalars['String']>;
   readonly originatingDataId?: Maybe<Scalars['uuid']>;
   readonly registrantId?: Maybe<Scalars['uuid']>;
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
+};
+
+/** aggregate stddev on columns */
+export type Collection_ProgramPersonWithAccessToken_Stddev_Fields = {
+  readonly __typename?: 'collection_ProgramPersonWithAccessToken_stddev_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Collection_ProgramPersonWithAccessToken_Stddev_Pop_Fields = {
+  readonly __typename?: 'collection_ProgramPersonWithAccessToken_stddev_pop_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Collection_ProgramPersonWithAccessToken_Stddev_Samp_Fields = {
+  readonly __typename?: 'collection_ProgramPersonWithAccessToken_stddev_samp_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate sum on columns */
+export type Collection_ProgramPersonWithAccessToken_Sum_Fields = {
+  readonly __typename?: 'collection_ProgramPersonWithAccessToken_sum_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
+};
+
+/** aggregate var_pop on columns */
+export type Collection_ProgramPersonWithAccessToken_Var_Pop_Fields = {
+  readonly __typename?: 'collection_ProgramPersonWithAccessToken_var_pop_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate var_samp on columns */
+export type Collection_ProgramPersonWithAccessToken_Var_Samp_Fields = {
+  readonly __typename?: 'collection_ProgramPersonWithAccessToken_var_samp_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate variance on columns */
+export type Collection_ProgramPersonWithAccessToken_Variance_Fields = {
+  readonly __typename?: 'collection_ProgramPersonWithAccessToken_variance_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
 };
 
 /** aggregated selection of "collection.ProgramPerson" */
@@ -6886,9 +6962,17 @@ export type Collection_ProgramPerson_Aggregate = {
 /** aggregate fields of "collection.ProgramPerson" */
 export type Collection_ProgramPerson_Aggregate_Fields = {
   readonly __typename?: 'collection_ProgramPerson_aggregate_fields';
+  readonly avg?: Maybe<Collection_ProgramPerson_Avg_Fields>;
   readonly count: Scalars['Int'];
   readonly max?: Maybe<Collection_ProgramPerson_Max_Fields>;
   readonly min?: Maybe<Collection_ProgramPerson_Min_Fields>;
+  readonly stddev?: Maybe<Collection_ProgramPerson_Stddev_Fields>;
+  readonly stddev_pop?: Maybe<Collection_ProgramPerson_Stddev_Pop_Fields>;
+  readonly stddev_samp?: Maybe<Collection_ProgramPerson_Stddev_Samp_Fields>;
+  readonly sum?: Maybe<Collection_ProgramPerson_Sum_Fields>;
+  readonly var_pop?: Maybe<Collection_ProgramPerson_Var_Pop_Fields>;
+  readonly var_samp?: Maybe<Collection_ProgramPerson_Var_Samp_Fields>;
+  readonly variance?: Maybe<Collection_ProgramPerson_Variance_Fields>;
 };
 
 
@@ -6900,9 +6984,17 @@ export type Collection_ProgramPerson_Aggregate_FieldsCountArgs = {
 
 /** order by aggregate values of table "collection.ProgramPerson" */
 export type Collection_ProgramPerson_Aggregate_Order_By = {
+  readonly avg?: Maybe<Collection_ProgramPerson_Avg_Order_By>;
   readonly count?: Maybe<Order_By>;
   readonly max?: Maybe<Collection_ProgramPerson_Max_Order_By>;
   readonly min?: Maybe<Collection_ProgramPerson_Min_Order_By>;
+  readonly stddev?: Maybe<Collection_ProgramPerson_Stddev_Order_By>;
+  readonly stddev_pop?: Maybe<Collection_ProgramPerson_Stddev_Pop_Order_By>;
+  readonly stddev_samp?: Maybe<Collection_ProgramPerson_Stddev_Samp_Order_By>;
+  readonly sum?: Maybe<Collection_ProgramPerson_Sum_Order_By>;
+  readonly var_pop?: Maybe<Collection_ProgramPerson_Var_Pop_Order_By>;
+  readonly var_samp?: Maybe<Collection_ProgramPerson_Var_Samp_Order_By>;
+  readonly variance?: Maybe<Collection_ProgramPerson_Variance_Order_By>;
 };
 
 /** input type for inserting array relation for remote table "collection.ProgramPerson" */
@@ -6910,6 +7002,17 @@ export type Collection_ProgramPerson_Arr_Rel_Insert_Input = {
   readonly data: ReadonlyArray<Collection_ProgramPerson_Insert_Input>;
   /** on conflict condition */
   readonly on_conflict?: Maybe<Collection_ProgramPerson_On_Conflict>;
+};
+
+/** aggregate avg on columns */
+export type Collection_ProgramPerson_Avg_Fields = {
+  readonly __typename?: 'collection_ProgramPerson_avg_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Avg_Order_By = {
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "collection.ProgramPerson". All fields are combined with a logical 'AND'. */
@@ -6930,6 +7033,7 @@ export type Collection_ProgramPerson_Bool_Exp = {
   readonly originatingDataId?: Maybe<Uuid_Comparison_Exp>;
   readonly registrant?: Maybe<Registrant_Registrant_Bool_Exp>;
   readonly registrantId?: Maybe<Uuid_Comparison_Exp>;
+  readonly submissionRequestsSentCount?: Maybe<Int_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "collection.ProgramPerson" */
@@ -6941,6 +7045,11 @@ export enum Collection_ProgramPerson_Constraint {
   /** unique or primary key constraint */
   CollectionProgramPersonAccessToken = 'collection_ProgramPerson_accessToken'
 }
+
+/** input type for incrementing numeric columns in table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Inc_Input = {
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
+};
 
 /** input type for inserting data into table "collection.ProgramPerson" */
 export type Collection_ProgramPerson_Insert_Input = {
@@ -6957,6 +7066,7 @@ export type Collection_ProgramPerson_Insert_Input = {
   readonly originatingDataId?: Maybe<Scalars['uuid']>;
   readonly registrant?: Maybe<Registrant_Registrant_Obj_Rel_Insert_Input>;
   readonly registrantId?: Maybe<Scalars['uuid']>;
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -6970,6 +7080,7 @@ export type Collection_ProgramPerson_Max_Fields = {
   readonly name?: Maybe<Scalars['String']>;
   readonly originatingDataId?: Maybe<Scalars['uuid']>;
   readonly registrantId?: Maybe<Scalars['uuid']>;
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "collection.ProgramPerson" */
@@ -6982,6 +7093,7 @@ export type Collection_ProgramPerson_Max_Order_By = {
   readonly name?: Maybe<Order_By>;
   readonly originatingDataId?: Maybe<Order_By>;
   readonly registrantId?: Maybe<Order_By>;
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -6995,6 +7107,7 @@ export type Collection_ProgramPerson_Min_Fields = {
   readonly name?: Maybe<Scalars['String']>;
   readonly originatingDataId?: Maybe<Scalars['uuid']>;
   readonly registrantId?: Maybe<Scalars['uuid']>;
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "collection.ProgramPerson" */
@@ -7007,6 +7120,7 @@ export type Collection_ProgramPerson_Min_Order_By = {
   readonly name?: Maybe<Order_By>;
   readonly originatingDataId?: Maybe<Order_By>;
   readonly registrantId?: Maybe<Order_By>;
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "collection.ProgramPerson" */
@@ -7047,6 +7161,7 @@ export type Collection_ProgramPerson_Order_By = {
   readonly originatingDataId?: Maybe<Order_By>;
   readonly registrant?: Maybe<Registrant_Registrant_Order_By>;
   readonly registrantId?: Maybe<Order_By>;
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: collection_ProgramPerson */
@@ -7071,7 +7186,9 @@ export enum Collection_ProgramPerson_Select_Column {
   /** column name */
   OriginatingDataId = 'originatingDataId',
   /** column name */
-  RegistrantId = 'registrantId'
+  RegistrantId = 'registrantId',
+  /** column name */
+  SubmissionRequestsSentCount = 'submissionRequestsSentCount'
 }
 
 /** input type for updating data in table "collection.ProgramPerson" */
@@ -7084,6 +7201,51 @@ export type Collection_ProgramPerson_Set_Input = {
   readonly name?: Maybe<Scalars['String']>;
   readonly originatingDataId?: Maybe<Scalars['uuid']>;
   readonly registrantId?: Maybe<Scalars['uuid']>;
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
+};
+
+/** aggregate stddev on columns */
+export type Collection_ProgramPerson_Stddev_Fields = {
+  readonly __typename?: 'collection_ProgramPerson_stddev_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Stddev_Order_By = {
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Collection_ProgramPerson_Stddev_Pop_Fields = {
+  readonly __typename?: 'collection_ProgramPerson_stddev_pop_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Stddev_Pop_Order_By = {
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Collection_ProgramPerson_Stddev_Samp_Fields = {
+  readonly __typename?: 'collection_ProgramPerson_stddev_samp_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Stddev_Samp_Order_By = {
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Collection_ProgramPerson_Sum_Fields = {
+  readonly __typename?: 'collection_ProgramPerson_sum_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Int']>;
+};
+
+/** order by sum() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Sum_Order_By = {
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** update columns of table "collection.ProgramPerson" */
@@ -7103,8 +7265,43 @@ export enum Collection_ProgramPerson_Update_Column {
   /** column name */
   OriginatingDataId = 'originatingDataId',
   /** column name */
-  RegistrantId = 'registrantId'
+  RegistrantId = 'registrantId',
+  /** column name */
+  SubmissionRequestsSentCount = 'submissionRequestsSentCount'
 }
+
+/** aggregate var_pop on columns */
+export type Collection_ProgramPerson_Var_Pop_Fields = {
+  readonly __typename?: 'collection_ProgramPerson_var_pop_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Var_Pop_Order_By = {
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Collection_ProgramPerson_Var_Samp_Fields = {
+  readonly __typename?: 'collection_ProgramPerson_var_samp_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Var_Samp_Order_By = {
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Collection_ProgramPerson_Variance_Fields = {
+  readonly __typename?: 'collection_ProgramPerson_variance_fields';
+  readonly submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Variance_Order_By = {
+  readonly submissionRequestsSentCount?: Maybe<Order_By>;
+};
 
 /** columns and relationships of "collection.Tag" */
 export type Collection_Tag = {
@@ -9292,6 +9489,8 @@ export type Content_Element = {
   readonly conferenceId: Scalars['uuid'];
   readonly createdAt: Scalars['timestamptz'];
   readonly data: Scalars['jsonb'];
+  /** A computed field, executes function "content.elementHasBeenSubmitted" */
+  readonly hasBeenSubmitted?: Maybe<Scalars['Boolean']>;
   readonly id: Scalars['uuid'];
   readonly isHidden: Scalars['Boolean'];
   /** An object relationship */
@@ -10472,6 +10671,7 @@ export type Content_Element_Bool_Exp = {
   readonly conferenceId?: Maybe<Uuid_Comparison_Exp>;
   readonly createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   readonly data?: Maybe<Jsonb_Comparison_Exp>;
+  readonly hasBeenSubmitted?: Maybe<Boolean_Comparison_Exp>;
   readonly id?: Maybe<Uuid_Comparison_Exp>;
   readonly isHidden?: Maybe<Boolean_Comparison_Exp>;
   readonly item?: Maybe<Content_Item_Bool_Exp>;
@@ -10632,6 +10832,7 @@ export type Content_Element_Order_By = {
   readonly conferenceId?: Maybe<Order_By>;
   readonly createdAt?: Maybe<Order_By>;
   readonly data?: Maybe<Order_By>;
+  readonly hasBeenSubmitted?: Maybe<Order_By>;
   readonly id?: Maybe<Order_By>;
   readonly isHidden?: Maybe<Order_By>;
   readonly item?: Maybe<Content_Item_Order_By>;
@@ -10836,6 +11037,8 @@ export type Content_Item = {
   readonly events: ReadonlyArray<Schedule_Event>;
   /** An aggregate relationship */
   readonly events_aggregate: Schedule_Event_Aggregate;
+  /** A computed field, executes function "content.itemHasUnsubmittedElements" */
+  readonly hasUnsubmittedElements?: Maybe<Scalars['Boolean']>;
   readonly id: Scalars['uuid'];
   /** An array relationship */
   readonly itemExhibitions: ReadonlyArray<Content_ItemExhibition>;
@@ -11569,6 +11772,8 @@ export type Content_ItemProgramPerson = {
   /** An object relationship */
   readonly conference: Conference_Conference;
   readonly conferenceId: Scalars['uuid'];
+  /** A computed field, executes function "content.itemProgramPerson_HasSubmissionRequestBeenSent" */
+  readonly hasSubmissionRequestBeenSent?: Maybe<Scalars['Boolean']>;
   readonly id: Scalars['uuid'];
   /** An object relationship */
   readonly item: Content_Item;
@@ -11576,6 +11781,8 @@ export type Content_ItemProgramPerson = {
   /** An object relationship */
   readonly person: Collection_ProgramPerson;
   readonly personId: Scalars['uuid'];
+  /** An object relationship */
+  readonly personWithAccessToken?: Maybe<Collection_ProgramPersonWithAccessToken>;
   readonly priority?: Maybe<Scalars['Int']>;
   readonly roleName: Scalars['String'];
 };
@@ -11924,11 +12131,13 @@ export type Content_ItemProgramPerson_Bool_Exp = {
   readonly _or?: Maybe<ReadonlyArray<Content_ItemProgramPerson_Bool_Exp>>;
   readonly conference?: Maybe<Conference_Conference_Bool_Exp>;
   readonly conferenceId?: Maybe<Uuid_Comparison_Exp>;
+  readonly hasSubmissionRequestBeenSent?: Maybe<Boolean_Comparison_Exp>;
   readonly id?: Maybe<Uuid_Comparison_Exp>;
   readonly item?: Maybe<Content_Item_Bool_Exp>;
   readonly itemId?: Maybe<Uuid_Comparison_Exp>;
   readonly person?: Maybe<Collection_ProgramPerson_Bool_Exp>;
   readonly personId?: Maybe<Uuid_Comparison_Exp>;
+  readonly personWithAccessToken?: Maybe<Collection_ProgramPersonWithAccessToken_Bool_Exp>;
   readonly priority?: Maybe<Int_Comparison_Exp>;
   readonly roleName?: Maybe<String_Comparison_Exp>;
 };
@@ -11955,6 +12164,7 @@ export type Content_ItemProgramPerson_Insert_Input = {
   readonly itemId?: Maybe<Scalars['uuid']>;
   readonly person?: Maybe<Collection_ProgramPerson_Obj_Rel_Insert_Input>;
   readonly personId?: Maybe<Scalars['uuid']>;
+  readonly personWithAccessToken?: Maybe<Collection_ProgramPersonWithAccessToken_Obj_Rel_Insert_Input>;
   readonly priority?: Maybe<Scalars['Int']>;
   readonly roleName?: Maybe<Scalars['String']>;
 };
@@ -12021,11 +12231,13 @@ export type Content_ItemProgramPerson_On_Conflict = {
 export type Content_ItemProgramPerson_Order_By = {
   readonly conference?: Maybe<Conference_Conference_Order_By>;
   readonly conferenceId?: Maybe<Order_By>;
+  readonly hasSubmissionRequestBeenSent?: Maybe<Order_By>;
   readonly id?: Maybe<Order_By>;
   readonly item?: Maybe<Content_Item_Order_By>;
   readonly itemId?: Maybe<Order_By>;
   readonly person?: Maybe<Collection_ProgramPerson_Order_By>;
   readonly personId?: Maybe<Order_By>;
+  readonly personWithAccessToken?: Maybe<Collection_ProgramPersonWithAccessToken_Order_By>;
   readonly priority?: Maybe<Order_By>;
   readonly roleName?: Maybe<Order_By>;
 };
@@ -12526,6 +12738,7 @@ export type Content_Item_Bool_Exp = {
   readonly createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   readonly elements?: Maybe<Content_Element_Bool_Exp>;
   readonly events?: Maybe<Schedule_Event_Bool_Exp>;
+  readonly hasUnsubmittedElements?: Maybe<Boolean_Comparison_Exp>;
   readonly id?: Maybe<Uuid_Comparison_Exp>;
   readonly itemExhibitions?: Maybe<Content_ItemExhibition_Bool_Exp>;
   readonly itemPeople?: Maybe<Content_ItemProgramPerson_Bool_Exp>;
@@ -12657,6 +12870,7 @@ export type Content_Item_Order_By = {
   readonly createdAt?: Maybe<Order_By>;
   readonly elements_aggregate?: Maybe<Content_Element_Aggregate_Order_By>;
   readonly events_aggregate?: Maybe<Schedule_Event_Aggregate_Order_By>;
+  readonly hasUnsubmittedElements?: Maybe<Order_By>;
   readonly id?: Maybe<Order_By>;
   readonly itemExhibitions_aggregate?: Maybe<Content_ItemExhibition_Aggregate_Order_By>;
   readonly itemPeople_aggregate?: Maybe<Content_ItemProgramPerson_Aggregate_Order_By>;
@@ -14519,11 +14733,14 @@ export type Job_Queues_SubmissionRequestEmailJob = {
   readonly created_at: Scalars['timestamptz'];
   readonly emailTemplate?: Maybe<Scalars['jsonb']>;
   readonly id: Scalars['uuid'];
+  /** An object relationship */
+  readonly person?: Maybe<Collection_ProgramPerson>;
+  readonly personId?: Maybe<Scalars['uuid']>;
   readonly processed: Scalars['Boolean'];
   readonly updated_at: Scalars['timestamptz'];
   /** An object relationship */
-  readonly uploader: Content_Uploader;
-  readonly uploaderId: Scalars['uuid'];
+  readonly uploader?: Maybe<Content_Uploader>;
+  readonly uploaderId?: Maybe<Scalars['uuid']>;
 };
 
 
@@ -14567,6 +14784,8 @@ export type Job_Queues_SubmissionRequestEmailJob_Bool_Exp = {
   readonly created_at?: Maybe<Timestamptz_Comparison_Exp>;
   readonly emailTemplate?: Maybe<Jsonb_Comparison_Exp>;
   readonly id?: Maybe<Uuid_Comparison_Exp>;
+  readonly person?: Maybe<Collection_ProgramPerson_Bool_Exp>;
+  readonly personId?: Maybe<Uuid_Comparison_Exp>;
   readonly processed?: Maybe<Boolean_Comparison_Exp>;
   readonly updated_at?: Maybe<Timestamptz_Comparison_Exp>;
   readonly uploader?: Maybe<Content_Uploader_Bool_Exp>;
@@ -14599,6 +14818,8 @@ export type Job_Queues_SubmissionRequestEmailJob_Insert_Input = {
   readonly created_at?: Maybe<Scalars['timestamptz']>;
   readonly emailTemplate?: Maybe<Scalars['jsonb']>;
   readonly id?: Maybe<Scalars['uuid']>;
+  readonly person?: Maybe<Collection_ProgramPerson_Obj_Rel_Insert_Input>;
+  readonly personId?: Maybe<Scalars['uuid']>;
   readonly processed?: Maybe<Scalars['Boolean']>;
   readonly updated_at?: Maybe<Scalars['timestamptz']>;
   readonly uploader?: Maybe<Content_Uploader_Obj_Rel_Insert_Input>;
@@ -14610,6 +14831,7 @@ export type Job_Queues_SubmissionRequestEmailJob_Max_Fields = {
   readonly __typename?: 'job_queues_SubmissionRequestEmailJob_max_fields';
   readonly created_at?: Maybe<Scalars['timestamptz']>;
   readonly id?: Maybe<Scalars['uuid']>;
+  readonly personId?: Maybe<Scalars['uuid']>;
   readonly updated_at?: Maybe<Scalars['timestamptz']>;
   readonly uploaderId?: Maybe<Scalars['uuid']>;
 };
@@ -14619,6 +14841,7 @@ export type Job_Queues_SubmissionRequestEmailJob_Min_Fields = {
   readonly __typename?: 'job_queues_SubmissionRequestEmailJob_min_fields';
   readonly created_at?: Maybe<Scalars['timestamptz']>;
   readonly id?: Maybe<Scalars['uuid']>;
+  readonly personId?: Maybe<Scalars['uuid']>;
   readonly updated_at?: Maybe<Scalars['timestamptz']>;
   readonly uploaderId?: Maybe<Scalars['uuid']>;
 };
@@ -14644,6 +14867,8 @@ export type Job_Queues_SubmissionRequestEmailJob_Order_By = {
   readonly created_at?: Maybe<Order_By>;
   readonly emailTemplate?: Maybe<Order_By>;
   readonly id?: Maybe<Order_By>;
+  readonly person?: Maybe<Collection_ProgramPerson_Order_By>;
+  readonly personId?: Maybe<Order_By>;
   readonly processed?: Maybe<Order_By>;
   readonly updated_at?: Maybe<Order_By>;
   readonly uploader?: Maybe<Content_Uploader_Order_By>;
@@ -14669,6 +14894,8 @@ export enum Job_Queues_SubmissionRequestEmailJob_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
+  PersonId = 'personId',
+  /** column name */
   Processed = 'processed',
   /** column name */
   UpdatedAt = 'updated_at',
@@ -14681,6 +14908,7 @@ export type Job_Queues_SubmissionRequestEmailJob_Set_Input = {
   readonly created_at?: Maybe<Scalars['timestamptz']>;
   readonly emailTemplate?: Maybe<Scalars['jsonb']>;
   readonly id?: Maybe<Scalars['uuid']>;
+  readonly personId?: Maybe<Scalars['uuid']>;
   readonly processed?: Maybe<Scalars['Boolean']>;
   readonly updated_at?: Maybe<Scalars['timestamptz']>;
   readonly uploaderId?: Maybe<Scalars['uuid']>;
@@ -14694,6 +14922,8 @@ export enum Job_Queues_SubmissionRequestEmailJob_Update_Column {
   EmailTemplate = 'emailTemplate',
   /** column name */
   Id = 'id',
+  /** column name */
+  PersonId = 'personId',
   /** column name */
   Processed = 'processed',
   /** column name */
@@ -18923,6 +19153,7 @@ export type Mutation_RootUpdate_Collection_Exhibition_By_PkArgs = {
 
 /** mutation root */
 export type Mutation_RootUpdate_Collection_ProgramPersonArgs = {
+  _inc?: Maybe<Collection_ProgramPerson_Inc_Input>;
   _set?: Maybe<Collection_ProgramPerson_Set_Input>;
   where: Collection_ProgramPerson_Bool_Exp;
 };
@@ -18937,6 +19168,7 @@ export type Mutation_RootUpdate_Collection_ProgramPersonByAccessTokenArgs = {
 
 /** mutation root */
 export type Mutation_RootUpdate_Collection_ProgramPersonWithAccessTokenArgs = {
+  _inc?: Maybe<Collection_ProgramPersonWithAccessToken_Inc_Input>;
   _set?: Maybe<Collection_ProgramPersonWithAccessToken_Set_Input>;
   where: Collection_ProgramPersonWithAccessToken_Bool_Exp;
 };
@@ -18944,6 +19176,7 @@ export type Mutation_RootUpdate_Collection_ProgramPersonWithAccessTokenArgs = {
 
 /** mutation root */
 export type Mutation_RootUpdate_Collection_ProgramPerson_By_PkArgs = {
+  _inc?: Maybe<Collection_ProgramPerson_Inc_Input>;
   _set?: Maybe<Collection_ProgramPerson_Set_Input>;
   pk_columns: Collection_ProgramPerson_Pk_Columns_Input;
 };
@@ -37554,13 +37787,13 @@ export type ManageContent_RoomFragment = { readonly __typename?: 'room_Room', re
 
 export type ManageContent_ElementFragment = { readonly __typename?: 'content_Element', readonly id: any, readonly itemId: any, readonly name: string, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly layoutData?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly isHidden: boolean, readonly updatedAt: any, readonly conferenceId: any };
 
-export type ManageContent_ProgramPersonFragment = { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> };
+export type ManageContent_ProgramPersonFragment = { readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> };
 
-export type ManageContent_ItemProgramPersonFragment = { readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> } };
+export type ManageContent_ItemProgramPersonFragment = { readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> }> };
 
 export type ManageContent_ItemSecondaryFragment = { readonly __typename?: 'content_Item', readonly typeName: Content_ItemType_Enum, readonly chatId?: Maybe<any>, readonly rooms: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly id: any, readonly name: string }>, readonly originatingData?: Maybe<{ readonly __typename?: 'conference_OriginatingData', readonly id: any, readonly conferenceId: any, readonly sourceId: string, readonly data?: Maybe<any> }> };
 
-export type ManageContent_ItemForExportFragment = { readonly __typename?: 'content_Item', readonly id: any, readonly conferenceId: any, readonly title: string, readonly shortTitle?: Maybe<string>, readonly typeName: Content_ItemType_Enum, readonly originatingDataId?: Maybe<any>, readonly chatId?: Maybe<any>, readonly itemTags: ReadonlyArray<{ readonly __typename?: 'content_ItemTag', readonly id: any, readonly tagId: any }>, readonly itemExhibitions: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly exhibitionId: any, readonly priority?: Maybe<number> }>, readonly rooms: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly id: any }>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> } }>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly itemId: any, readonly name: string, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly layoutData?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly isHidden: boolean, readonly updatedAt: any, readonly conferenceId: any, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly email: string, readonly name: string, readonly emailsSentCount: number }> }> };
+export type ManageContent_ItemForExportFragment = { readonly __typename?: 'content_Item', readonly id: any, readonly conferenceId: any, readonly title: string, readonly shortTitle?: Maybe<string>, readonly typeName: Content_ItemType_Enum, readonly originatingDataId?: Maybe<any>, readonly chatId?: Maybe<any>, readonly itemTags: ReadonlyArray<{ readonly __typename?: 'content_ItemTag', readonly id: any, readonly tagId: any }>, readonly itemExhibitions: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly exhibitionId: any, readonly priority?: Maybe<number> }>, readonly rooms: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly id: any }>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> }> }>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly itemId: any, readonly name: string, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly layoutData?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly isHidden: boolean, readonly updatedAt: any, readonly conferenceId: any, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly email: string, readonly name: string, readonly emailsSentCount: number }> }> };
 
 export type ManageContent_SelectAllItemsQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -37574,7 +37807,7 @@ export type ManageContent_SelectItemsForExportQueryVariables = Exact<{
 }>;
 
 
-export type ManageContent_SelectItemsForExportQuery = { readonly __typename?: 'query_root', readonly content_Item: ReadonlyArray<{ readonly __typename?: 'content_Item', readonly id: any, readonly conferenceId: any, readonly title: string, readonly shortTitle?: Maybe<string>, readonly typeName: Content_ItemType_Enum, readonly originatingDataId?: Maybe<any>, readonly chatId?: Maybe<any>, readonly itemTags: ReadonlyArray<{ readonly __typename?: 'content_ItemTag', readonly id: any, readonly tagId: any }>, readonly itemExhibitions: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly exhibitionId: any, readonly priority?: Maybe<number> }>, readonly rooms: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly id: any }>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> } }>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly itemId: any, readonly name: string, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly layoutData?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly isHidden: boolean, readonly updatedAt: any, readonly conferenceId: any, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly email: string, readonly name: string, readonly emailsSentCount: number }> }> }> };
+export type ManageContent_SelectItemsForExportQuery = { readonly __typename?: 'query_root', readonly content_Item: ReadonlyArray<{ readonly __typename?: 'content_Item', readonly id: any, readonly conferenceId: any, readonly title: string, readonly shortTitle?: Maybe<string>, readonly typeName: Content_ItemType_Enum, readonly originatingDataId?: Maybe<any>, readonly chatId?: Maybe<any>, readonly itemTags: ReadonlyArray<{ readonly __typename?: 'content_ItemTag', readonly id: any, readonly tagId: any }>, readonly itemExhibitions: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly exhibitionId: any, readonly priority?: Maybe<number> }>, readonly rooms: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly id: any }>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> }> }>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly itemId: any, readonly name: string, readonly typeName: Content_ElementType_Enum, readonly data: any, readonly layoutData?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly isHidden: boolean, readonly updatedAt: any, readonly conferenceId: any, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly email: string, readonly name: string, readonly emailsSentCount: number }> }> }> };
 
 export type ManageContent_SelectItemQueryVariables = Exact<{
   itemId: Scalars['uuid'];
@@ -37588,7 +37821,7 @@ export type ManageContent_SelectItemPeopleQueryVariables = Exact<{
 }>;
 
 
-export type ManageContent_SelectItemPeopleQuery = { readonly __typename?: 'query_root', readonly content_ItemProgramPerson: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> } }> };
+export type ManageContent_SelectItemPeopleQuery = { readonly __typename?: 'query_root', readonly content_ItemProgramPerson: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> }> }> };
 
 export type ManageContent_InsertItemMutationVariables = Exact<{
   item: Content_Item_Insert_Input;
@@ -38038,7 +38271,7 @@ export type ManageContent_SelectProgramPeopleQueryVariables = Exact<{
 }>;
 
 
-export type ManageContent_SelectProgramPeopleQuery = { readonly __typename?: 'query_root', readonly collection_ProgramPerson: ReadonlyArray<{ readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> }> };
+export type ManageContent_SelectProgramPeopleQuery = { readonly __typename?: 'query_root', readonly collection_ProgramPersonWithAccessToken: ReadonlyArray<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> }> };
 
 export type ManageContent_InsertItemProgramPersonMutationVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -38049,7 +38282,7 @@ export type ManageContent_InsertItemProgramPersonMutationVariables = Exact<{
 }>;
 
 
-export type ManageContent_InsertItemProgramPersonMutation = { readonly __typename?: 'mutation_root', readonly insert_content_ItemProgramPerson_one?: Maybe<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> } }> };
+export type ManageContent_InsertItemProgramPersonMutation = { readonly __typename?: 'mutation_root', readonly insert_content_ItemProgramPerson_one?: Maybe<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> }> }> };
 
 export type ManageContent_UpdateItemProgramPersonMutationVariables = Exact<{
   itemPersonId: Scalars['uuid'];
@@ -38058,7 +38291,7 @@ export type ManageContent_UpdateItemProgramPersonMutationVariables = Exact<{
 }>;
 
 
-export type ManageContent_UpdateItemProgramPersonMutation = { readonly __typename?: 'mutation_root', readonly update_content_ItemProgramPerson_by_pk?: Maybe<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> } }> };
+export type ManageContent_UpdateItemProgramPersonMutation = { readonly __typename?: 'mutation_root', readonly update_content_ItemProgramPerson_by_pk?: Maybe<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly itemId: any, readonly priority?: Maybe<number>, readonly roleName: string, readonly person?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly registrantId?: Maybe<any> }> }> };
 
 export type ManageContent_DeleteItemProgramPersonMutationVariables = Exact<{
   itemPersonId: Scalars['uuid'];
@@ -38130,20 +38363,22 @@ export type SubmissionRequestsModalDataQueryVariables = Exact<{
 }>;
 
 
-export type SubmissionRequestsModalDataQuery = { readonly __typename?: 'query_root', readonly conference_Configuration: ReadonlyArray<{ readonly __typename?: 'conference_Configuration', readonly conferenceId: any, readonly key: Conference_ConfigurationKey_Enum, readonly value: any }>, readonly content_Element: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly itemId: any, readonly itemTitle?: Maybe<string>, readonly typeName: Content_ElementType_Enum, readonly name: string, readonly data: any, readonly uploadsRemaining?: Maybe<number>, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly email: string, readonly name: string, readonly emailsSentCount: number }> }> };
+export type SubmissionRequestsModalDataQuery = { readonly __typename?: 'query_root', readonly conference_Configuration: ReadonlyArray<{ readonly __typename?: 'conference_Configuration', readonly conferenceId: any, readonly key: Conference_ConfigurationKey_Enum, readonly value: any }>, readonly content_Item: ReadonlyArray<{ readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly typeName: Content_ItemType_Enum, readonly hasUnsubmittedElements?: Maybe<boolean>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly personId: any, readonly roleName: string, readonly hasSubmissionRequestBeenSent?: Maybe<boolean> }> }> };
 
 export type SubmissionRequestsModal_ConferenceConfigurationFragment = { readonly __typename?: 'conference_Configuration', readonly conferenceId: any, readonly key: Conference_ConfigurationKey_Enum, readonly value: any };
 
-export type SubmissionRequestsModal_ElementFragment = { readonly __typename?: 'content_Element', readonly id: any, readonly itemId: any, readonly itemTitle?: Maybe<string>, readonly typeName: Content_ElementType_Enum, readonly name: string, readonly data: any, readonly uploadsRemaining?: Maybe<number>, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly email: string, readonly name: string, readonly emailsSentCount: number }> };
+export type SubmissionRequestsModal_ItemFragment = { readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly typeName: Content_ItemType_Enum, readonly hasUnsubmittedElements?: Maybe<boolean>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly personId: any, readonly roleName: string, readonly hasSubmissionRequestBeenSent?: Maybe<boolean> }> };
 
 export type SubmissionsReviewModalDataQueryVariables = Exact<{
   itemIds: ReadonlyArray<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type SubmissionsReviewModalDataQuery = { readonly __typename?: 'query_root', readonly content_Element: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly itemId: any, readonly typeName: Content_ElementType_Enum, readonly name: string, readonly data: any, readonly layoutData?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly itemTitle?: Maybe<string>, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly email: string, readonly name: string, readonly emailsSentCount: number }> }> };
+export type SubmissionsReviewModalDataQuery = { readonly __typename?: 'query_root', readonly content_Item: ReadonlyArray<{ readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly hasUnsubmittedElements?: Maybe<boolean>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly person?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly name?: Maybe<string>, readonly submissionRequestsSentCount?: Maybe<number> }> }>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly typeName: Content_ElementType_Enum, readonly name: string, readonly data: any }> }> };
 
-export type SubmissionsReviewModal_ElementFragment = { readonly __typename?: 'content_Element', readonly id: any, readonly itemId: any, readonly typeName: Content_ElementType_Enum, readonly name: string, readonly data: any, readonly layoutData?: Maybe<any>, readonly uploadsRemaining?: Maybe<number>, readonly itemTitle?: Maybe<string>, readonly uploaders: ReadonlyArray<{ readonly __typename?: 'content_Uploader', readonly id: any, readonly email: string, readonly name: string, readonly emailsSentCount: number }> };
+export type SubmissionsReviewModal_ItemFragment = { readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly hasUnsubmittedElements?: Maybe<boolean>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly person?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly name?: Maybe<string>, readonly submissionRequestsSentCount?: Maybe<number> }> }>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly typeName: Content_ElementType_Enum, readonly name: string, readonly data: any }> };
+
+export type SubmissionsReviewModal_ElementFragment = { readonly __typename?: 'content_Element', readonly id: any, readonly typeName: Content_ElementType_Enum, readonly name: string, readonly data: any };
 
 export type ConfigureEmailTemplates_GetConferenceConfigurationsQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -38322,8 +38557,6 @@ export type UpdateGroupMutation = { readonly __typename?: 'mutation_root', reado
 
 export type ManageProgramPeople_RegistrantFragment = { readonly __typename?: 'registrant_Registrant', readonly id: any, readonly displayName: string, readonly invitation?: Maybe<{ readonly __typename?: 'registrant_Invitation', readonly id: any, readonly invitedEmailAddress: string }>, readonly profile?: Maybe<{ readonly __typename?: 'registrant_Profile', readonly registrantId: any, readonly affiliation?: Maybe<string> }> };
 
-export type ManageProgramPeople_ProgramPersonFragment = { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly conferenceId: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly registrantId?: Maybe<any> };
-
 export type ManageProgramPeople_ProgramPersonWithAccessTokenFragment = { readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly conferenceId?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly registrantId?: Maybe<any>, readonly accessToken?: Maybe<string> };
 
 export type ManageProgramPeople_SelectAllPeopleQueryVariables = Exact<{
@@ -38341,18 +38574,18 @@ export type ManageProgramPeople_SelectAllRegistrantsQueryVariables = Exact<{
 export type ManageProgramPeople_SelectAllRegistrantsQuery = { readonly __typename?: 'query_root', readonly registrant_Registrant: ReadonlyArray<{ readonly __typename?: 'registrant_Registrant', readonly id: any, readonly displayName: string, readonly invitation?: Maybe<{ readonly __typename?: 'registrant_Invitation', readonly id: any, readonly invitedEmailAddress: string }>, readonly profile?: Maybe<{ readonly __typename?: 'registrant_Profile', readonly registrantId: any, readonly affiliation?: Maybe<string> }> }> };
 
 export type ManageProgramPeople_InsertProgramPersonMutationVariables = Exact<{
-  person: Collection_ProgramPerson_Insert_Input;
+  person: Collection_ProgramPersonWithAccessToken_Insert_Input;
 }>;
 
 
-export type ManageProgramPeople_InsertProgramPersonMutation = { readonly __typename?: 'mutation_root', readonly insert_collection_ProgramPerson_one?: Maybe<{ readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly conferenceId: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly registrantId?: Maybe<any> }> };
+export type ManageProgramPeople_InsertProgramPersonMutation = { readonly __typename?: 'mutation_root', readonly insert_collection_ProgramPersonWithAccessToken_one?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly conferenceId?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly registrantId?: Maybe<any>, readonly accessToken?: Maybe<string> }> };
 
 export type ManageProgramPeople_DeleteProgramPersonsMutationVariables = Exact<{
   ids?: Maybe<ReadonlyArray<Scalars['uuid']> | Scalars['uuid']>;
 }>;
 
 
-export type ManageProgramPeople_DeleteProgramPersonsMutation = { readonly __typename?: 'mutation_root', readonly delete_collection_ProgramPerson?: Maybe<{ readonly __typename?: 'collection_ProgramPerson_mutation_response', readonly returning: ReadonlyArray<{ readonly __typename?: 'collection_ProgramPerson', readonly id: any }> }> };
+export type ManageProgramPeople_DeleteProgramPersonsMutation = { readonly __typename?: 'mutation_root', readonly delete_collection_ProgramPersonWithAccessToken?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken_mutation_response', readonly returning: ReadonlyArray<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any> }> }> };
 
 export type ManageProgramPeople_UpdateProgramPersonMutationVariables = Exact<{
   id: Scalars['uuid'];
@@ -38363,7 +38596,7 @@ export type ManageProgramPeople_UpdateProgramPersonMutationVariables = Exact<{
 }>;
 
 
-export type ManageProgramPeople_UpdateProgramPersonMutation = { readonly __typename?: 'mutation_root', readonly update_collection_ProgramPerson_by_pk?: Maybe<{ readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly conferenceId: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly registrantId?: Maybe<any> }> };
+export type ManageProgramPeople_UpdateProgramPersonMutation = { readonly __typename?: 'mutation_root', readonly update_collection_ProgramPersonWithAccessToken?: Maybe<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken_mutation_response', readonly returning: ReadonlyArray<{ readonly __typename?: 'collection_ProgramPersonWithAccessToken', readonly id?: Maybe<any>, readonly conferenceId?: Maybe<any>, readonly name?: Maybe<string>, readonly affiliation?: Maybe<string>, readonly email?: Maybe<string>, readonly originatingDataId?: Maybe<any>, readonly registrantId?: Maybe<any>, readonly accessToken?: Maybe<string> }> }> };
 
 export type SelectAllPermissionsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -38906,7 +39139,7 @@ export type CreateNewConferenceMetaStructureMutationVariables = Exact<{
 }>;
 
 
-export type CreateNewConferenceMetaStructureMutation = { readonly __typename?: 'mutation_root', readonly insert_registrant_Registrant?: Maybe<{ readonly __typename?: 'registrant_Registrant_mutation_response', readonly affected_rows: number }>, readonly insert_permissions_Group?: Maybe<{ readonly __typename?: 'permissions_Group_mutation_response', readonly returning: ReadonlyArray<{ readonly __typename?: 'permissions_Group', readonly id: any, readonly conferenceId: any, readonly name: string, readonly enabled: boolean, readonly groupRoles: ReadonlyArray<{ readonly __typename?: 'permissions_GroupRole', readonly id: any, readonly roleId: any, readonly groupId: any, readonly role: { readonly __typename?: 'permissions_Role', readonly id: any, readonly name: string, readonly conferenceId: any, readonly rolePermissions: ReadonlyArray<{ readonly __typename?: 'permissions_RolePermission', readonly id: any, readonly roleId: any, readonly permissionName: Permissions_Permission_Enum }> } }> }> }>, readonly insert_content_Item?: Maybe<{ readonly __typename?: 'content_Item_mutation_response', readonly returning: ReadonlyArray<{ readonly __typename?: 'content_Item', readonly id: any, readonly title: string, readonly typeName: Content_ItemType_Enum, readonly chatId?: Maybe<any>, readonly chat?: Maybe<{ readonly __typename?: 'chat_Chat', readonly rooms: ReadonlyArray<{ readonly __typename?: 'room_Room', readonly id: any, readonly name: string }> }>, readonly elements: ReadonlyArray<{ readonly __typename?: 'content_Element', readonly id: any, readonly data: any, readonly layoutData?: Maybe<any>, readonly name: string, readonly typeName: Content_ElementType_Enum }>, readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly roleName: string, readonly priority?: Maybe<number>, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly registrantId?: Maybe<any> } }>, readonly itemTags: ReadonlyArray<{ readonly __typename?: 'content_ItemTag', readonly id: any, readonly itemId: any, readonly tag: { readonly __typename?: 'collection_Tag', readonly id: any, readonly name: string, readonly colour: string, readonly priority: number } }>, readonly itemExhibitions: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly itemId: any, readonly exhibition: { readonly __typename?: 'collection_Exhibition', readonly id: any, readonly name: string, readonly colour: string, readonly priority: number, readonly items: ReadonlyArray<{ readonly __typename?: 'content_ItemExhibition', readonly id: any, readonly item: { readonly __typename?: 'content_Item', readonly itemPeople: ReadonlyArray<{ readonly __typename?: 'content_ItemProgramPerson', readonly id: any, readonly roleName: string, readonly priority?: Maybe<number>, readonly person: { readonly __typename?: 'collection_ProgramPerson', readonly id: any, readonly name: string, readonly affiliation?: Maybe<string>, readonly registrantId?: Maybe<any> } }>, readonly itemTags: ReadonlyArray<{ readonly __typename?: 'content_ItemTag', readonly id: any, readonly itemId: any, readonly tag: { readonly __typename?: 'collection_Tag', readonly id: any, readonly name: string, readonly colour: string, readonly priority: number } }> } }> } }> }> }> };
+export type CreateNewConferenceMetaStructureMutation = { readonly __typename?: 'mutation_root', readonly insert_registrant_Registrant?: Maybe<{ readonly __typename?: 'registrant_Registrant_mutation_response', readonly affected_rows: number }>, readonly insert_permissions_Group?: Maybe<{ readonly __typename?: 'permissions_Group_mutation_response', readonly returning: ReadonlyArray<{ readonly __typename?: 'permissions_Group', readonly id: any, readonly conferenceId: any, readonly name: string, readonly enabled: boolean, readonly groupRoles: ReadonlyArray<{ readonly __typename?: 'permissions_GroupRole', readonly id: any, readonly roleId: any, readonly groupId: any, readonly role: { readonly __typename?: 'permissions_Role', readonly id: any, readonly name: string, readonly conferenceId: any, readonly rolePermissions: ReadonlyArray<{ readonly __typename?: 'permissions_RolePermission', readonly id: any, readonly roleId: any, readonly permissionName: Permissions_Permission_Enum }> } }> }> }>, readonly insert_content_Item?: Maybe<{ readonly __typename?: 'content_Item_mutation_response', readonly affected_rows: number }> };
 
 export type RegistrantsByIdQueryVariables = Exact<{
   conferenceId: Scalars['uuid'];
@@ -39347,7 +39580,9 @@ export const ItemElements_ItemDataFragmentDoc = gql`
       name
     }
   }
-  elements(where: {isHidden: {_eq: false}}) {
+  elements(
+    where: {isHidden: {_eq: false}, _or: [{typeName: {_in: [ACTIVE_SOCIAL_ROOMS, CONTENT_GROUP_LIST, DIVIDER, EXPLORE_PROGRAM_BUTTON, EXPLORE_SCHEDULE_BUTTON, LIVE_PROGRAM_ROOMS, SPONSOR_BOOTHS, WHOLE_SCHEDULE]}}, {hasBeenSubmitted: {_eq: true}}]}
+  ) {
     ...ElementData
   }
   itemPeople(order_by: {priority: asc}) {
@@ -40212,7 +40447,7 @@ export const ManageContent_ItemSecondaryFragmentDoc = gql`
     ${ManageContent_RoomFragmentDoc}
 ${ManageContent_OriginatingDataFragmentDoc}`;
 export const ManageContent_ProgramPersonFragmentDoc = gql`
-    fragment ManageContent_ProgramPerson on collection_ProgramPerson {
+    fragment ManageContent_ProgramPerson on collection_ProgramPersonWithAccessToken {
   id
   name
   affiliation
@@ -40226,7 +40461,7 @@ export const ManageContent_ItemProgramPersonFragmentDoc = gql`
   itemId
   priority
   roleName
-  person {
+  person: personWithAccessToken {
     ...ManageContent_ProgramPerson
   }
 }
@@ -40481,41 +40716,46 @@ export const SubmissionRequestsModal_ConferenceConfigurationFragmentDoc = gql`
   value
 }
     `;
-export const SubmissionRequestsModal_ElementFragmentDoc = gql`
-    fragment SubmissionRequestsModal_Element on content_Element {
+export const SubmissionRequestsModal_ItemFragmentDoc = gql`
+    fragment SubmissionRequestsModal_Item on content_Item {
   id
-  itemId
-  itemTitle
+  title
   typeName
-  name
-  data
-  uploadsRemaining
-  uploaders {
+  hasUnsubmittedElements
+  itemPeople {
     id
-    email
-    name
-    emailsSentCount
+    personId
+    roleName
+    hasSubmissionRequestBeenSent
   }
 }
     `;
 export const SubmissionsReviewModal_ElementFragmentDoc = gql`
     fragment SubmissionsReviewModal_Element on content_Element {
   id
-  itemId
   typeName
   name
   data
-  layoutData
-  uploadsRemaining
-  itemTitle
-  uploaders {
-    id
-    email
-    name
-    emailsSentCount
-  }
 }
     `;
+export const SubmissionsReviewModal_ItemFragmentDoc = gql`
+    fragment SubmissionsReviewModal_Item on content_Item {
+  id
+  title
+  hasUnsubmittedElements
+  itemPeople {
+    id
+    person: personWithAccessToken {
+      id
+      name
+      submissionRequestsSentCount
+    }
+  }
+  elements {
+    ...SubmissionsReviewModal_Element
+  }
+}
+    ${SubmissionsReviewModal_ElementFragmentDoc}`;
 export const ConfigureEmailTemplates_ConferenceConfigurationFragmentDoc = gql`
     fragment ConfigureEmailTemplates_ConferenceConfiguration on conference_Configuration {
   conferenceId
@@ -40592,17 +40832,6 @@ export const ManageProgramPeople_RegistrantFragmentDoc = gql`
     registrantId
     affiliation
   }
-}
-    `;
-export const ManageProgramPeople_ProgramPersonFragmentDoc = gql`
-    fragment ManageProgramPeople_ProgramPerson on collection_ProgramPerson {
-  id
-  conferenceId
-  name
-  affiliation
-  email
-  originatingDataId
-  registrantId
 }
     `;
 export const ManageProgramPeople_ProgramPersonWithAccessTokenFragmentDoc = gql`
@@ -46769,7 +46998,9 @@ export type Item_CreateRoomMutationResult = Apollo.MutationResult<Item_CreateRoo
 export type Item_CreateRoomMutationOptions = Apollo.BaseMutationOptions<Item_CreateRoomMutation, Item_CreateRoomMutationVariables>;
 export const ManageContent_SelectProgramPeopleDocument = gql`
     query ManageContent_SelectProgramPeople($conferenceId: uuid!) {
-  collection_ProgramPerson(where: {conferenceId: {_eq: $conferenceId}}) {
+  collection_ProgramPersonWithAccessToken(
+    where: {conferenceId: {_eq: $conferenceId}}
+  ) {
     ...ManageContent_ProgramPerson
   }
 }
@@ -47171,12 +47402,12 @@ export const SubmissionRequestsModalDataDocument = gql`
   conference_Configuration(where: {conferenceId: {_eq: $conferenceId}}) {
     ...ConfigureEmailTemplates_ConferenceConfiguration
   }
-  content_Element(where: {itemId: {_in: $itemIds}}) {
-    ...SubmissionRequestsModal_Element
+  content_Item(where: {id: {_in: $itemIds}}) {
+    ...SubmissionRequestsModal_Item
   }
 }
     ${ConfigureEmailTemplates_ConferenceConfigurationFragmentDoc}
-${SubmissionRequestsModal_ElementFragmentDoc}`;
+${SubmissionRequestsModal_ItemFragmentDoc}`;
 
 /**
  * __useSubmissionRequestsModalDataQuery__
@@ -47208,11 +47439,11 @@ export type SubmissionRequestsModalDataLazyQueryHookResult = ReturnType<typeof u
 export type SubmissionRequestsModalDataQueryResult = Apollo.QueryResult<SubmissionRequestsModalDataQuery, SubmissionRequestsModalDataQueryVariables>;
 export const SubmissionsReviewModalDataDocument = gql`
     query SubmissionsReviewModalData($itemIds: [uuid!]!) {
-  content_Element(where: {itemId: {_in: $itemIds}}) {
-    ...SubmissionsReviewModal_Element
+  content_Item(where: {id: {_in: $itemIds}}) {
+    ...SubmissionsReviewModal_Item
   }
 }
-    ${SubmissionsReviewModal_ElementFragmentDoc}`;
+    ${SubmissionsReviewModal_ItemFragmentDoc}`;
 
 /**
  * __useSubmissionsReviewModalDataQuery__
@@ -48201,12 +48432,12 @@ export type ManageProgramPeople_SelectAllRegistrantsQueryHookResult = ReturnType
 export type ManageProgramPeople_SelectAllRegistrantsLazyQueryHookResult = ReturnType<typeof useManageProgramPeople_SelectAllRegistrantsLazyQuery>;
 export type ManageProgramPeople_SelectAllRegistrantsQueryResult = Apollo.QueryResult<ManageProgramPeople_SelectAllRegistrantsQuery, ManageProgramPeople_SelectAllRegistrantsQueryVariables>;
 export const ManageProgramPeople_InsertProgramPersonDocument = gql`
-    mutation ManageProgramPeople_InsertProgramPerson($person: collection_ProgramPerson_insert_input!) {
-  insert_collection_ProgramPerson_one(object: $person) {
-    ...ManageProgramPeople_ProgramPerson
+    mutation ManageProgramPeople_InsertProgramPerson($person: collection_ProgramPersonWithAccessToken_insert_input!) {
+  insert_collection_ProgramPersonWithAccessToken_one(object: $person) {
+    ...ManageProgramPeople_ProgramPersonWithAccessToken
   }
 }
-    ${ManageProgramPeople_ProgramPersonFragmentDoc}`;
+    ${ManageProgramPeople_ProgramPersonWithAccessTokenFragmentDoc}`;
 export type ManageProgramPeople_InsertProgramPersonMutationFn = Apollo.MutationFunction<ManageProgramPeople_InsertProgramPersonMutation, ManageProgramPeople_InsertProgramPersonMutationVariables>;
 
 /**
@@ -48235,7 +48466,7 @@ export type ManageProgramPeople_InsertProgramPersonMutationResult = Apollo.Mutat
 export type ManageProgramPeople_InsertProgramPersonMutationOptions = Apollo.BaseMutationOptions<ManageProgramPeople_InsertProgramPersonMutation, ManageProgramPeople_InsertProgramPersonMutationVariables>;
 export const ManageProgramPeople_DeleteProgramPersonsDocument = gql`
     mutation ManageProgramPeople_DeleteProgramPersons($ids: [uuid!] = []) {
-  delete_collection_ProgramPerson(where: {id: {_in: $ids}}) {
+  delete_collection_ProgramPersonWithAccessToken(where: {id: {_in: $ids}}) {
     returning {
       id
     }
@@ -48270,14 +48501,16 @@ export type ManageProgramPeople_DeleteProgramPersonsMutationResult = Apollo.Muta
 export type ManageProgramPeople_DeleteProgramPersonsMutationOptions = Apollo.BaseMutationOptions<ManageProgramPeople_DeleteProgramPersonsMutation, ManageProgramPeople_DeleteProgramPersonsMutationVariables>;
 export const ManageProgramPeople_UpdateProgramPersonDocument = gql`
     mutation ManageProgramPeople_UpdateProgramPerson($id: uuid!, $name: String!, $affiliation: String, $email: String, $registrantId: uuid) {
-  update_collection_ProgramPerson_by_pk(
-    pk_columns: {id: $id}
+  update_collection_ProgramPersonWithAccessToken(
+    where: {id: {_eq: $id}}
     _set: {name: $name, affiliation: $affiliation, email: $email, registrantId: $registrantId}
   ) {
-    ...ManageProgramPeople_ProgramPerson
+    returning {
+      ...ManageProgramPeople_ProgramPersonWithAccessToken
+    }
   }
 }
-    ${ManageProgramPeople_ProgramPersonFragmentDoc}`;
+    ${ManageProgramPeople_ProgramPersonWithAccessTokenFragmentDoc}`;
 export type ManageProgramPeople_UpdateProgramPersonMutationFn = Apollo.MutationFunction<ManageProgramPeople_UpdateProgramPersonMutation, ManageProgramPeople_UpdateProgramPersonMutationVariables>;
 
 /**
@@ -50748,12 +50981,10 @@ export const CreateNewConferenceMetaStructureDocument = gql`
   insert_content_Item(
     objects: {conferenceId: $conferenceId, typeName: LANDING_PAGE, elements: {data: [{conferenceId: $conferenceId, typeName: ABSTRACT, data: $abstractData, isHidden: false, layoutData: null, name: "Welcome text"}, {conferenceId: $conferenceId, typeName: CONTENT_GROUP_LIST, data: $itemListData, isHidden: false, layoutData: null, name: "Content group list"}]}, shortTitle: "Landing", title: "Landing page"}
   ) {
-    returning {
-      ...ItemElements_ItemData
-    }
+    affected_rows
   }
 }
-    ${ItemElements_ItemDataFragmentDoc}`;
+    `;
 export type CreateNewConferenceMetaStructureMutationFn = Apollo.MutationFunction<CreateNewConferenceMetaStructureMutation, CreateNewConferenceMetaStructureMutationVariables>;
 
 /**

--- a/hasura/metadata/tables.yaml
+++ b/hasura/metadata/tables.yaml
@@ -1300,12 +1300,10 @@
     permission:
       columns:
       - affiliation
-      - registrantId
       - conferenceId
-      - email
       - id
       - name
-      - originatingDataId
+      - registrantId
       filter:
         conference:
           _and:
@@ -1325,12 +1323,10 @@
     permission:
       columns:
       - affiliation
-      - registrantId
       - conferenceId
-      - email
       - id
       - name
-      - originatingDataId
+      - registrantId
       filter:
         _and:
         - conference:
@@ -1474,18 +1470,102 @@
         insertion_order: null
         column_mapping:
           id: personId
+  insert_permissions:
+  - role: user
+    permission:
+      check:
+        _and:
+        - conference:
+            slug:
+              _eq: X-Hasura-Conference-Slug
+        - _exists:
+            _where:
+              _and:
+              - user_id:
+                  _eq: X-Hasura-User-Id
+              - slug:
+                  _eq: X-Hasura-Conference-Slug
+              - permission_name:
+                  _in:
+                  - CONFERENCE_MANAGE_CONTENT
+                  - CONFERENCE_MANAGE_SCHEDULE
+            _table:
+              schema: public
+              name: FlatUserPermission
+      columns:
+      - affiliation
+      - conferenceId
+      - email
+      - id
+      - name
+      - originatingDataId
+      - registrantId
+      backend_only: false
   select_permissions:
   - role: user
     permission:
       columns:
-      - id
-      - conferenceId
-      - name
+      - accessToken
       - affiliation
+      - conferenceId
+      - email
+      - id
+      - name
       - originatingDataId
       - registrantId
-      - email
+      - submissionRequestsSentCount
+      filter:
+        _and:
+        - conference:
+            slug:
+              _eq: X-Hasura-Conference-Slug
+        - _exists:
+            _where:
+              _and:
+              - user_id:
+                  _eq: X-Hasura-User-Id
+              - slug:
+                  _eq: X-Hasura-Conference-Slug
+              - permission_name:
+                  _in:
+                  - CONFERENCE_MANAGE_CONTENT
+                  - CONFERENCE_MANAGE_SCHEDULE
+            _table:
+              schema: public
+              name: FlatUserPermission
+  update_permissions:
+  - role: user
+    permission:
+      columns:
       - accessToken
+      - affiliation
+      - email
+      - name
+      - originatingDataId
+      - registrantId
+      filter:
+        _and:
+        - conference:
+            slug:
+              _eq: X-Hasura-Conference-Slug
+        - _exists:
+            _where:
+              _and:
+              - user_id:
+                  _eq: X-Hasura-User-Id
+              - slug:
+                  _eq: X-Hasura-Conference-Slug
+              - permission_name:
+                  _in:
+                  - CONFERENCE_MANAGE_CONTENT
+                  - CONFERENCE_MANAGE_SCHEDULE
+            _table:
+              schema: public
+              name: FlatUserPermission
+      check: null
+  delete_permissions:
+  - role: user
+    permission:
       filter:
         _and:
         - conference:
@@ -2364,6 +2444,11 @@
           schema: video
           name: YouTubeUpload
   computed_fields:
+  - name: hasBeenSubmitted
+    definition:
+      function:
+        schema: content
+        name: elementHasBeenSubmitted
   - name: itemTitle
     definition:
       function:
@@ -2427,6 +2512,7 @@
       - updated_at
       - uploadsRemaining
       computed_fields:
+      - hasBeenSubmitted
       - itemTitle
       filter:
         _and:
@@ -2516,6 +2602,7 @@
       - updated_at
       - uploadsRemaining
       computed_fields:
+      - hasBeenSubmitted
       - itemTitle
       - uploadersCount
       filter:
@@ -3086,6 +3173,12 @@
         table:
           schema: analytics
           name: ContentItemStats
+  computed_fields:
+  - name: hasUnsubmittedElements
+    definition:
+      function:
+        schema: content
+        name: itemHasUnsubmittedElements
   insert_permissions:
   - role: user
     permission:
@@ -3151,12 +3244,15 @@
       columns:
       - chatId
       - conferenceId
-      - typeName
+      - created_at
       - id
       - originatingDataId
       - shortTitle
       - title
+      - typeName
       - updated_at
+      computed_fields:
+      - hasUnsubmittedElements
       filter:
         _and:
         - conference:
@@ -3448,6 +3544,21 @@
   - name: person
     using:
       foreign_key_constraint_on: personId
+  - name: personWithAccessToken
+    using:
+      manual_configuration:
+        remote_table:
+          schema: collection
+          name: ProgramPersonWithAccessToken
+        insertion_order: null
+        column_mapping:
+          personId: id
+  computed_fields:
+  - name: hasSubmissionRequestBeenSent
+    definition:
+      function:
+        schema: content
+        name: itemProgramPerson_HasSubmissionRequestBeenSent
   insert_permissions:
   - role: user
     permission:
@@ -3510,6 +3621,8 @@
       - personId
       - priority
       - roleName
+      computed_fields:
+      - hasSubmissionRequestBeenSent
       filter:
         _and:
         - conference:
@@ -4209,6 +4322,9 @@
     schema: job_queues
     name: SubmissionRequestEmailJob
   object_relationships:
+  - name: person
+    using:
+      foreign_key_constraint_on: personId
   - name: uploader
     using:
       foreign_key_constraint_on: uploaderId
@@ -4216,26 +4332,46 @@
   - role: user
     permission:
       check:
-        uploader:
-          conference:
-            _or:
-            - createdBy:
-                _eq: X-Hasura-User-Id
-            - groups:
-                _and:
-                - enabled:
-                    _eq: true
-                - groupRoles:
-                    role:
-                      rolePermissions:
-                        permissionName:
-                          _eq: CONFERENCE_MANAGE_CONTENT
-                - groupRegistrants:
-                    registrant:
-                      userId:
-                        _eq: X-Hasura-User-Id
+        _or:
+        - uploader:
+            conference:
+              _or:
+              - createdBy:
+                  _eq: X-Hasura-User-Id
+              - groups:
+                  _and:
+                  - enabled:
+                      _eq: true
+                  - groupRoles:
+                      role:
+                        rolePermissions:
+                          permissionName:
+                            _eq: CONFERENCE_MANAGE_CONTENT
+                  - groupRegistrants:
+                      registrant:
+                        userId:
+                          _eq: X-Hasura-User-Id
+        - person:
+            conference:
+              _or:
+              - createdBy:
+                  _eq: X-Hasura-User-Id
+              - groups:
+                  _and:
+                  - enabled:
+                      _eq: true
+                  - groupRoles:
+                      role:
+                        rolePermissions:
+                          permissionName:
+                            _eq: CONFERENCE_MANAGE_CONTENT
+                  - groupRegistrants:
+                      registrant:
+                        userId:
+                          _eq: X-Hasura-User-Id
       columns:
       - emailTemplate
+      - personId
       - uploaderId
       backend_only: false
 - table:

--- a/hasura/migrations/1631874259461_alter_table_job_queues_SubmissionRequestEmailJob_add_column_personId/down.sql
+++ b/hasura/migrations/1631874259461_alter_table_job_queues_SubmissionRequestEmailJob_add_column_personId/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "job_queues"."SubmissionRequestEmailJob" add column "personId" uuid
+--  null;

--- a/hasura/migrations/1631874259461_alter_table_job_queues_SubmissionRequestEmailJob_add_column_personId/up.sql
+++ b/hasura/migrations/1631874259461_alter_table_job_queues_SubmissionRequestEmailJob_add_column_personId/up.sql
@@ -1,0 +1,2 @@
+alter table "job_queues"."SubmissionRequestEmailJob" add column "personId" uuid
+ null;

--- a/hasura/migrations/1631874269299_alter_table_job_queues_SubmissionRequestEmailJob_alter_column_uploaderId/down.sql
+++ b/hasura/migrations/1631874269299_alter_table_job_queues_SubmissionRequestEmailJob_alter_column_uploaderId/down.sql
@@ -1,0 +1,1 @@
+alter table "job_queues"."SubmissionRequestEmailJob" alter column "uploaderId" set not null;

--- a/hasura/migrations/1631874269299_alter_table_job_queues_SubmissionRequestEmailJob_alter_column_uploaderId/up.sql
+++ b/hasura/migrations/1631874269299_alter_table_job_queues_SubmissionRequestEmailJob_alter_column_uploaderId/up.sql
@@ -1,0 +1,1 @@
+alter table "job_queues"."SubmissionRequestEmailJob" alter column "uploaderId" drop not null;

--- a/hasura/migrations/1631874296355_set_fk_job_queues_SubmissionRequestEmailJob_personId/down.sql
+++ b/hasura/migrations/1631874296355_set_fk_job_queues_SubmissionRequestEmailJob_personId/down.sql
@@ -1,0 +1,1 @@
+alter table "job_queues"."SubmissionRequestEmailJob" drop constraint "SubmissionRequestEmailJob_personId_fkey";

--- a/hasura/migrations/1631874296355_set_fk_job_queues_SubmissionRequestEmailJob_personId/up.sql
+++ b/hasura/migrations/1631874296355_set_fk_job_queues_SubmissionRequestEmailJob_personId/up.sql
@@ -1,0 +1,5 @@
+alter table "job_queues"."SubmissionRequestEmailJob"
+  add constraint "SubmissionRequestEmailJob_personId_fkey"
+  foreign key ("personId")
+  references "collection"."ProgramPerson"
+  ("id") on update cascade on delete cascade;

--- a/hasura/migrations/1631874309695_set_fk_job_queues_SubmissionRequestEmailJob_personId/down.sql
+++ b/hasura/migrations/1631874309695_set_fk_job_queues_SubmissionRequestEmailJob_personId/down.sql
@@ -1,0 +1,5 @@
+alter table "job_queues"."SubmissionRequestEmailJob" drop constraint "SubmissionRequestEmailJob_personId_fkey",
+  add constraint "SubmissionRequestEmailJob_personId_fkey"
+  foreign key ("uploaderId")
+  references "content"."Uploader"
+  ("id") on update cascade on delete cascade;

--- a/hasura/migrations/1631874309695_set_fk_job_queues_SubmissionRequestEmailJob_personId/up.sql
+++ b/hasura/migrations/1631874309695_set_fk_job_queues_SubmissionRequestEmailJob_personId/up.sql
@@ -1,0 +1,5 @@
+alter table "job_queues"."SubmissionRequestEmailJob" drop constraint "SubmissionRequestEmailJob_personId_fkey",
+  add constraint "SubmissionRequestEmailJob_personId_fkey"
+  foreign key ("personId")
+  references "collection"."ProgramPerson"
+  ("id") on update cascade on delete set null;

--- a/hasura/migrations/1631874328915_set_fk_job_queues_SubmissionRequestEmailJob_uploaderId/down.sql
+++ b/hasura/migrations/1631874328915_set_fk_job_queues_SubmissionRequestEmailJob_uploaderId/down.sql
@@ -1,0 +1,5 @@
+alter table "job_queues"."SubmissionRequestEmailJob" drop constraint "SubmissionRequestEmailJob_uploaderId_fkey",
+  add constraint "SubmissionRequestEmailJob_uploaderId_fkey"
+  foreign key ("uploaderId")
+  references "content"."Uploader"
+  ("id") on update cascade on delete cascade;

--- a/hasura/migrations/1631874328915_set_fk_job_queues_SubmissionRequestEmailJob_uploaderId/up.sql
+++ b/hasura/migrations/1631874328915_set_fk_job_queues_SubmissionRequestEmailJob_uploaderId/up.sql
@@ -1,0 +1,5 @@
+alter table "job_queues"."SubmissionRequestEmailJob" drop constraint "SubmissionRequestEmailJob_uploaderId_fkey",
+  add constraint "SubmissionRequestEmailJob_uploaderId_fkey"
+  foreign key ("uploaderId")
+  references "content"."Uploader"
+  ("id") on update cascade on delete set null;

--- a/hasura/migrations/1631874955008_alter_table_collection_ProgramPerson_add_column_submissionRequestsSentCount/down.sql
+++ b/hasura/migrations/1631874955008_alter_table_collection_ProgramPerson_add_column_submissionRequestsSentCount/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- alter table "collection"."ProgramPerson" add column "submissionRequestsSentCount" integer
+--  not null default '0';

--- a/hasura/migrations/1631874955008_alter_table_collection_ProgramPerson_add_column_submissionRequestsSentCount/up.sql
+++ b/hasura/migrations/1631874955008_alter_table_collection_ProgramPerson_add_column_submissionRequestsSentCount/up.sql
@@ -1,0 +1,2 @@
+alter table "collection"."ProgramPerson" add column "submissionRequestsSentCount" integer
+ not null default '0';

--- a/hasura/migrations/1631875347455_run_sql_migration/down.sql
+++ b/hasura/migrations/1631875347455_run_sql_migration/down.sql
@@ -1,0 +1,12 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE FUNCTION "content"."elementHasBeenSubmitted"(el_row "content"."Element")
+-- RETURNS BOOLEAN AS $$
+-- BEGIN
+--    IF jsonb_typeof(el_row.data) = 'array' THEN
+--     RETURN jsonb_array_length(el_row.data) > 0;
+--    ELSE
+--     RETURN FALSE;
+--    END IF;
+-- END
+-- $$ LANGUAGE plpgsql STABLE;

--- a/hasura/migrations/1631875347455_run_sql_migration/up.sql
+++ b/hasura/migrations/1631875347455_run_sql_migration/up.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION "content"."elementHasBeenSubmitted"(el_row "content"."Element")
+RETURNS BOOLEAN AS $$
+BEGIN
+   IF jsonb_typeof(el_row.data) = 'array' THEN
+    RETURN jsonb_array_length(el_row.data) > 0;
+   ELSE
+    RETURN FALSE;
+   END IF;
+END
+$$ LANGUAGE plpgsql STABLE;

--- a/hasura/migrations/1631875900214_run_sql_migration/down.sql
+++ b/hasura/migrations/1631875900214_run_sql_migration/down.sql
@@ -1,0 +1,10 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE FUNCTION "content"."itemHasUnsubmittedElements"(item_row "content"."Item")
+-- RETURNS BOOLEAN AS $$
+--     SELECT 0 < (
+--         SELECT COUNT(*) FROM "content"."Element" AS element
+--         WHERE element."itemId" = item_row.id
+--         AND NOT content."elementHasBeenSubmitted"(element)
+--     )
+-- $$ LANGUAGE sql STABLE;

--- a/hasura/migrations/1631875900214_run_sql_migration/up.sql
+++ b/hasura/migrations/1631875900214_run_sql_migration/up.sql
@@ -1,0 +1,8 @@
+CREATE FUNCTION "content"."itemHasUnsubmittedElements"(item_row "content"."Item")
+RETURNS BOOLEAN AS $$
+    SELECT 0 < (
+        SELECT COUNT(*) FROM "content"."Element" AS element 
+        WHERE element."itemId" = item_row.id
+        AND NOT content."elementHasBeenSubmitted"(element)
+    )
+$$ LANGUAGE sql STABLE;

--- a/hasura/migrations/1631876121845_run_sql_migration/down.sql
+++ b/hasura/migrations/1631876121845_run_sql_migration/down.sql
@@ -1,0 +1,9 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE FUNCTION "content"."itemProgramPerson_HasSubmissionRequestBeenSent"(itemPerson_row "content"."ItemProgramPerson")
+-- RETURNS BOOLEAN AS $$
+--     SELECT 0 < (
+--         SELECT "submissionRequestsSentCount" FROM "collection"."ProgramPerson" AS person
+--         WHERE person.id = itemPerson_row."personId"
+--     )
+-- $$ LANGUAGE sql STABLE;

--- a/hasura/migrations/1631876121845_run_sql_migration/up.sql
+++ b/hasura/migrations/1631876121845_run_sql_migration/up.sql
@@ -1,0 +1,7 @@
+CREATE FUNCTION "content"."itemProgramPerson_HasSubmissionRequestBeenSent"(itemPerson_row "content"."ItemProgramPerson")
+RETURNS BOOLEAN AS $$
+    SELECT 0 < (
+        SELECT "submissionRequestsSentCount" FROM "collection"."ProgramPerson" AS person
+        WHERE person.id = itemPerson_row."personId"
+    )
+$$ LANGUAGE sql STABLE;

--- a/hasura/migrations/1631876268156_run_sql_migration/down.sql
+++ b/hasura/migrations/1631876268156_run_sql_migration/down.sql
@@ -1,0 +1,4 @@
+-- Could not auto-generate a down migration.
+-- Please write an appropriate down migration for the SQL below:
+-- CREATE OR REPLACE VIEW "collection"."ProgramPersonWithAccessToken" AS
+--  SELECT * FROM collection."ProgramPerson";

--- a/hasura/migrations/1631876268156_run_sql_migration/up.sql
+++ b/hasura/migrations/1631876268156_run_sql_migration/up.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE VIEW "collection"."ProgramPersonWithAccessToken" AS 
+ SELECT * FROM collection."ProgramPerson";

--- a/services/actions/src/generated/graphql.ts
+++ b/services/actions/src/generated/graphql.ts
@@ -6481,6 +6481,7 @@ export type Collection_ProgramPerson = {
   /** An object relationship */
   registrant?: Maybe<Registrant_Registrant>;
   registrantId?: Maybe<Scalars['uuid']>;
+  submissionRequestsSentCount: Scalars['Int'];
 };
 
 
@@ -6715,6 +6716,7 @@ export type Collection_ProgramPersonWithAccessToken = {
   /** An object relationship */
   registrant?: Maybe<Registrant_Registrant>;
   registrantId?: Maybe<Scalars['uuid']>;
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 
@@ -6747,9 +6749,17 @@ export type Collection_ProgramPersonWithAccessToken_Aggregate = {
 /** aggregate fields of "collection.ProgramPersonWithAccessToken" */
 export type Collection_ProgramPersonWithAccessToken_Aggregate_Fields = {
   __typename?: 'collection_ProgramPersonWithAccessToken_aggregate_fields';
+  avg?: Maybe<Collection_ProgramPersonWithAccessToken_Avg_Fields>;
   count: Scalars['Int'];
   max?: Maybe<Collection_ProgramPersonWithAccessToken_Max_Fields>;
   min?: Maybe<Collection_ProgramPersonWithAccessToken_Min_Fields>;
+  stddev?: Maybe<Collection_ProgramPersonWithAccessToken_Stddev_Fields>;
+  stddev_pop?: Maybe<Collection_ProgramPersonWithAccessToken_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Collection_ProgramPersonWithAccessToken_Stddev_Samp_Fields>;
+  sum?: Maybe<Collection_ProgramPersonWithAccessToken_Sum_Fields>;
+  var_pop?: Maybe<Collection_ProgramPersonWithAccessToken_Var_Pop_Fields>;
+  var_samp?: Maybe<Collection_ProgramPersonWithAccessToken_Var_Samp_Fields>;
+  variance?: Maybe<Collection_ProgramPersonWithAccessToken_Variance_Fields>;
 };
 
 
@@ -6757,6 +6767,12 @@ export type Collection_ProgramPersonWithAccessToken_Aggregate_Fields = {
 export type Collection_ProgramPersonWithAccessToken_Aggregate_FieldsCountArgs = {
   columns?: Maybe<Array<Collection_ProgramPersonWithAccessToken_Select_Column>>;
   distinct?: Maybe<Scalars['Boolean']>;
+};
+
+/** aggregate avg on columns */
+export type Collection_ProgramPersonWithAccessToken_Avg_Fields = {
+  __typename?: 'collection_ProgramPersonWithAccessToken_avg_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
 };
 
 /** Boolean expression to filter rows from the table "collection.ProgramPersonWithAccessToken". All fields are combined with a logical 'AND'. */
@@ -6775,6 +6791,12 @@ export type Collection_ProgramPersonWithAccessToken_Bool_Exp = {
   originatingDataId?: Maybe<Uuid_Comparison_Exp>;
   registrant?: Maybe<Registrant_Registrant_Bool_Exp>;
   registrantId?: Maybe<Uuid_Comparison_Exp>;
+  submissionRequestsSentCount?: Maybe<Int_Comparison_Exp>;
+};
+
+/** input type for incrementing numeric columns in table "collection.ProgramPersonWithAccessToken" */
+export type Collection_ProgramPersonWithAccessToken_Inc_Input = {
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** input type for inserting data into table "collection.ProgramPersonWithAccessToken" */
@@ -6790,6 +6812,7 @@ export type Collection_ProgramPersonWithAccessToken_Insert_Input = {
   originatingDataId?: Maybe<Scalars['uuid']>;
   registrant?: Maybe<Registrant_Registrant_Obj_Rel_Insert_Input>;
   registrantId?: Maybe<Scalars['uuid']>;
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -6803,6 +6826,7 @@ export type Collection_ProgramPersonWithAccessToken_Max_Fields = {
   name?: Maybe<Scalars['String']>;
   originatingDataId?: Maybe<Scalars['uuid']>;
   registrantId?: Maybe<Scalars['uuid']>;
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate min on columns */
@@ -6816,6 +6840,7 @@ export type Collection_ProgramPersonWithAccessToken_Min_Fields = {
   name?: Maybe<Scalars['String']>;
   originatingDataId?: Maybe<Scalars['uuid']>;
   registrantId?: Maybe<Scalars['uuid']>;
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** response of any mutation on the table "collection.ProgramPersonWithAccessToken" */
@@ -6825,6 +6850,11 @@ export type Collection_ProgramPersonWithAccessToken_Mutation_Response = {
   affected_rows: Scalars['Int'];
   /** data from the rows affected by the mutation */
   returning: Array<Collection_ProgramPersonWithAccessToken>;
+};
+
+/** input type for inserting object relation for remote table "collection.ProgramPersonWithAccessToken" */
+export type Collection_ProgramPersonWithAccessToken_Obj_Rel_Insert_Input = {
+  data: Collection_ProgramPersonWithAccessToken_Insert_Input;
 };
 
 /** Ordering options when selecting data from "collection.ProgramPersonWithAccessToken". */
@@ -6840,6 +6870,7 @@ export type Collection_ProgramPersonWithAccessToken_Order_By = {
   originatingDataId?: Maybe<Order_By>;
   registrant?: Maybe<Registrant_Registrant_Order_By>;
   registrantId?: Maybe<Order_By>;
+  submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** select columns of table "collection.ProgramPersonWithAccessToken" */
@@ -6859,7 +6890,9 @@ export enum Collection_ProgramPersonWithAccessToken_Select_Column {
   /** column name */
   OriginatingDataId = 'originatingDataId',
   /** column name */
-  RegistrantId = 'registrantId'
+  RegistrantId = 'registrantId',
+  /** column name */
+  SubmissionRequestsSentCount = 'submissionRequestsSentCount'
 }
 
 /** input type for updating data in table "collection.ProgramPersonWithAccessToken" */
@@ -6872,6 +6905,49 @@ export type Collection_ProgramPersonWithAccessToken_Set_Input = {
   name?: Maybe<Scalars['String']>;
   originatingDataId?: Maybe<Scalars['uuid']>;
   registrantId?: Maybe<Scalars['uuid']>;
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
+};
+
+/** aggregate stddev on columns */
+export type Collection_ProgramPersonWithAccessToken_Stddev_Fields = {
+  __typename?: 'collection_ProgramPersonWithAccessToken_stddev_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Collection_ProgramPersonWithAccessToken_Stddev_Pop_Fields = {
+  __typename?: 'collection_ProgramPersonWithAccessToken_stddev_pop_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Collection_ProgramPersonWithAccessToken_Stddev_Samp_Fields = {
+  __typename?: 'collection_ProgramPersonWithAccessToken_stddev_samp_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate sum on columns */
+export type Collection_ProgramPersonWithAccessToken_Sum_Fields = {
+  __typename?: 'collection_ProgramPersonWithAccessToken_sum_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
+};
+
+/** aggregate var_pop on columns */
+export type Collection_ProgramPersonWithAccessToken_Var_Pop_Fields = {
+  __typename?: 'collection_ProgramPersonWithAccessToken_var_pop_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate var_samp on columns */
+export type Collection_ProgramPersonWithAccessToken_Var_Samp_Fields = {
+  __typename?: 'collection_ProgramPersonWithAccessToken_var_samp_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** aggregate variance on columns */
+export type Collection_ProgramPersonWithAccessToken_Variance_Fields = {
+  __typename?: 'collection_ProgramPersonWithAccessToken_variance_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
 };
 
 /** aggregated selection of "collection.ProgramPerson" */
@@ -6884,9 +6960,17 @@ export type Collection_ProgramPerson_Aggregate = {
 /** aggregate fields of "collection.ProgramPerson" */
 export type Collection_ProgramPerson_Aggregate_Fields = {
   __typename?: 'collection_ProgramPerson_aggregate_fields';
+  avg?: Maybe<Collection_ProgramPerson_Avg_Fields>;
   count: Scalars['Int'];
   max?: Maybe<Collection_ProgramPerson_Max_Fields>;
   min?: Maybe<Collection_ProgramPerson_Min_Fields>;
+  stddev?: Maybe<Collection_ProgramPerson_Stddev_Fields>;
+  stddev_pop?: Maybe<Collection_ProgramPerson_Stddev_Pop_Fields>;
+  stddev_samp?: Maybe<Collection_ProgramPerson_Stddev_Samp_Fields>;
+  sum?: Maybe<Collection_ProgramPerson_Sum_Fields>;
+  var_pop?: Maybe<Collection_ProgramPerson_Var_Pop_Fields>;
+  var_samp?: Maybe<Collection_ProgramPerson_Var_Samp_Fields>;
+  variance?: Maybe<Collection_ProgramPerson_Variance_Fields>;
 };
 
 
@@ -6898,9 +6982,17 @@ export type Collection_ProgramPerson_Aggregate_FieldsCountArgs = {
 
 /** order by aggregate values of table "collection.ProgramPerson" */
 export type Collection_ProgramPerson_Aggregate_Order_By = {
+  avg?: Maybe<Collection_ProgramPerson_Avg_Order_By>;
   count?: Maybe<Order_By>;
   max?: Maybe<Collection_ProgramPerson_Max_Order_By>;
   min?: Maybe<Collection_ProgramPerson_Min_Order_By>;
+  stddev?: Maybe<Collection_ProgramPerson_Stddev_Order_By>;
+  stddev_pop?: Maybe<Collection_ProgramPerson_Stddev_Pop_Order_By>;
+  stddev_samp?: Maybe<Collection_ProgramPerson_Stddev_Samp_Order_By>;
+  sum?: Maybe<Collection_ProgramPerson_Sum_Order_By>;
+  var_pop?: Maybe<Collection_ProgramPerson_Var_Pop_Order_By>;
+  var_samp?: Maybe<Collection_ProgramPerson_Var_Samp_Order_By>;
+  variance?: Maybe<Collection_ProgramPerson_Variance_Order_By>;
 };
 
 /** input type for inserting array relation for remote table "collection.ProgramPerson" */
@@ -6908,6 +7000,17 @@ export type Collection_ProgramPerson_Arr_Rel_Insert_Input = {
   data: Array<Collection_ProgramPerson_Insert_Input>;
   /** on conflict condition */
   on_conflict?: Maybe<Collection_ProgramPerson_On_Conflict>;
+};
+
+/** aggregate avg on columns */
+export type Collection_ProgramPerson_Avg_Fields = {
+  __typename?: 'collection_ProgramPerson_avg_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Avg_Order_By = {
+  submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "collection.ProgramPerson". All fields are combined with a logical 'AND'. */
@@ -6928,6 +7031,7 @@ export type Collection_ProgramPerson_Bool_Exp = {
   originatingDataId?: Maybe<Uuid_Comparison_Exp>;
   registrant?: Maybe<Registrant_Registrant_Bool_Exp>;
   registrantId?: Maybe<Uuid_Comparison_Exp>;
+  submissionRequestsSentCount?: Maybe<Int_Comparison_Exp>;
 };
 
 /** unique or primary key constraints on table "collection.ProgramPerson" */
@@ -6939,6 +7043,11 @@ export enum Collection_ProgramPerson_Constraint {
   /** unique or primary key constraint */
   CollectionProgramPersonAccessToken = 'collection_ProgramPerson_accessToken'
 }
+
+/** input type for incrementing numeric columns in table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Inc_Input = {
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
+};
 
 /** input type for inserting data into table "collection.ProgramPerson" */
 export type Collection_ProgramPerson_Insert_Input = {
@@ -6955,6 +7064,7 @@ export type Collection_ProgramPerson_Insert_Input = {
   originatingDataId?: Maybe<Scalars['uuid']>;
   registrant?: Maybe<Registrant_Registrant_Obj_Rel_Insert_Input>;
   registrantId?: Maybe<Scalars['uuid']>;
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** aggregate max on columns */
@@ -6968,6 +7078,7 @@ export type Collection_ProgramPerson_Max_Fields = {
   name?: Maybe<Scalars['String']>;
   originatingDataId?: Maybe<Scalars['uuid']>;
   registrantId?: Maybe<Scalars['uuid']>;
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** order by max() on columns of table "collection.ProgramPerson" */
@@ -6980,6 +7091,7 @@ export type Collection_ProgramPerson_Max_Order_By = {
   name?: Maybe<Order_By>;
   originatingDataId?: Maybe<Order_By>;
   registrantId?: Maybe<Order_By>;
+  submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** aggregate min on columns */
@@ -6993,6 +7105,7 @@ export type Collection_ProgramPerson_Min_Fields = {
   name?: Maybe<Scalars['String']>;
   originatingDataId?: Maybe<Scalars['uuid']>;
   registrantId?: Maybe<Scalars['uuid']>;
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
 };
 
 /** order by min() on columns of table "collection.ProgramPerson" */
@@ -7005,6 +7118,7 @@ export type Collection_ProgramPerson_Min_Order_By = {
   name?: Maybe<Order_By>;
   originatingDataId?: Maybe<Order_By>;
   registrantId?: Maybe<Order_By>;
+  submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "collection.ProgramPerson" */
@@ -7045,6 +7159,7 @@ export type Collection_ProgramPerson_Order_By = {
   originatingDataId?: Maybe<Order_By>;
   registrant?: Maybe<Registrant_Registrant_Order_By>;
   registrantId?: Maybe<Order_By>;
+  submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** primary key columns input for table: collection_ProgramPerson */
@@ -7069,7 +7184,9 @@ export enum Collection_ProgramPerson_Select_Column {
   /** column name */
   OriginatingDataId = 'originatingDataId',
   /** column name */
-  RegistrantId = 'registrantId'
+  RegistrantId = 'registrantId',
+  /** column name */
+  SubmissionRequestsSentCount = 'submissionRequestsSentCount'
 }
 
 /** input type for updating data in table "collection.ProgramPerson" */
@@ -7082,6 +7199,51 @@ export type Collection_ProgramPerson_Set_Input = {
   name?: Maybe<Scalars['String']>;
   originatingDataId?: Maybe<Scalars['uuid']>;
   registrantId?: Maybe<Scalars['uuid']>;
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
+};
+
+/** aggregate stddev on columns */
+export type Collection_ProgramPerson_Stddev_Fields = {
+  __typename?: 'collection_ProgramPerson_stddev_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Stddev_Order_By = {
+  submissionRequestsSentCount?: Maybe<Order_By>;
+};
+
+/** aggregate stddev_pop on columns */
+export type Collection_ProgramPerson_Stddev_Pop_Fields = {
+  __typename?: 'collection_ProgramPerson_stddev_pop_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Stddev_Pop_Order_By = {
+  submissionRequestsSentCount?: Maybe<Order_By>;
+};
+
+/** aggregate stddev_samp on columns */
+export type Collection_ProgramPerson_Stddev_Samp_Fields = {
+  __typename?: 'collection_ProgramPerson_stddev_samp_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_samp() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Stddev_Samp_Order_By = {
+  submissionRequestsSentCount?: Maybe<Order_By>;
+};
+
+/** aggregate sum on columns */
+export type Collection_ProgramPerson_Sum_Fields = {
+  __typename?: 'collection_ProgramPerson_sum_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Int']>;
+};
+
+/** order by sum() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Sum_Order_By = {
+  submissionRequestsSentCount?: Maybe<Order_By>;
 };
 
 /** update columns of table "collection.ProgramPerson" */
@@ -7101,8 +7263,43 @@ export enum Collection_ProgramPerson_Update_Column {
   /** column name */
   OriginatingDataId = 'originatingDataId',
   /** column name */
-  RegistrantId = 'registrantId'
+  RegistrantId = 'registrantId',
+  /** column name */
+  SubmissionRequestsSentCount = 'submissionRequestsSentCount'
 }
+
+/** aggregate var_pop on columns */
+export type Collection_ProgramPerson_Var_Pop_Fields = {
+  __typename?: 'collection_ProgramPerson_var_pop_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_pop() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Var_Pop_Order_By = {
+  submissionRequestsSentCount?: Maybe<Order_By>;
+};
+
+/** aggregate var_samp on columns */
+export type Collection_ProgramPerson_Var_Samp_Fields = {
+  __typename?: 'collection_ProgramPerson_var_samp_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by var_samp() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Var_Samp_Order_By = {
+  submissionRequestsSentCount?: Maybe<Order_By>;
+};
+
+/** aggregate variance on columns */
+export type Collection_ProgramPerson_Variance_Fields = {
+  __typename?: 'collection_ProgramPerson_variance_fields';
+  submissionRequestsSentCount?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "collection.ProgramPerson" */
+export type Collection_ProgramPerson_Variance_Order_By = {
+  submissionRequestsSentCount?: Maybe<Order_By>;
+};
 
 /** columns and relationships of "collection.Tag" */
 export type Collection_Tag = {
@@ -9290,6 +9487,8 @@ export type Content_Element = {
   conferenceId: Scalars['uuid'];
   createdAt: Scalars['timestamptz'];
   data: Scalars['jsonb'];
+  /** A computed field, executes function "content.elementHasBeenSubmitted" */
+  hasBeenSubmitted?: Maybe<Scalars['Boolean']>;
   id: Scalars['uuid'];
   isHidden: Scalars['Boolean'];
   /** An object relationship */
@@ -10470,6 +10669,7 @@ export type Content_Element_Bool_Exp = {
   conferenceId?: Maybe<Uuid_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   data?: Maybe<Jsonb_Comparison_Exp>;
+  hasBeenSubmitted?: Maybe<Boolean_Comparison_Exp>;
   id?: Maybe<Uuid_Comparison_Exp>;
   isHidden?: Maybe<Boolean_Comparison_Exp>;
   item?: Maybe<Content_Item_Bool_Exp>;
@@ -10630,6 +10830,7 @@ export type Content_Element_Order_By = {
   conferenceId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
   data?: Maybe<Order_By>;
+  hasBeenSubmitted?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   isHidden?: Maybe<Order_By>;
   item?: Maybe<Content_Item_Order_By>;
@@ -10834,6 +11035,8 @@ export type Content_Item = {
   events: Array<Schedule_Event>;
   /** An aggregate relationship */
   events_aggregate: Schedule_Event_Aggregate;
+  /** A computed field, executes function "content.itemHasUnsubmittedElements" */
+  hasUnsubmittedElements?: Maybe<Scalars['Boolean']>;
   id: Scalars['uuid'];
   /** An array relationship */
   itemExhibitions: Array<Content_ItemExhibition>;
@@ -11567,6 +11770,8 @@ export type Content_ItemProgramPerson = {
   /** An object relationship */
   conference: Conference_Conference;
   conferenceId: Scalars['uuid'];
+  /** A computed field, executes function "content.itemProgramPerson_HasSubmissionRequestBeenSent" */
+  hasSubmissionRequestBeenSent?: Maybe<Scalars['Boolean']>;
   id: Scalars['uuid'];
   /** An object relationship */
   item: Content_Item;
@@ -11574,6 +11779,8 @@ export type Content_ItemProgramPerson = {
   /** An object relationship */
   person: Collection_ProgramPerson;
   personId: Scalars['uuid'];
+  /** An object relationship */
+  personWithAccessToken?: Maybe<Collection_ProgramPersonWithAccessToken>;
   priority?: Maybe<Scalars['Int']>;
   roleName: Scalars['String'];
 };
@@ -11922,11 +12129,13 @@ export type Content_ItemProgramPerson_Bool_Exp = {
   _or?: Maybe<Array<Content_ItemProgramPerson_Bool_Exp>>;
   conference?: Maybe<Conference_Conference_Bool_Exp>;
   conferenceId?: Maybe<Uuid_Comparison_Exp>;
+  hasSubmissionRequestBeenSent?: Maybe<Boolean_Comparison_Exp>;
   id?: Maybe<Uuid_Comparison_Exp>;
   item?: Maybe<Content_Item_Bool_Exp>;
   itemId?: Maybe<Uuid_Comparison_Exp>;
   person?: Maybe<Collection_ProgramPerson_Bool_Exp>;
   personId?: Maybe<Uuid_Comparison_Exp>;
+  personWithAccessToken?: Maybe<Collection_ProgramPersonWithAccessToken_Bool_Exp>;
   priority?: Maybe<Int_Comparison_Exp>;
   roleName?: Maybe<String_Comparison_Exp>;
 };
@@ -11953,6 +12162,7 @@ export type Content_ItemProgramPerson_Insert_Input = {
   itemId?: Maybe<Scalars['uuid']>;
   person?: Maybe<Collection_ProgramPerson_Obj_Rel_Insert_Input>;
   personId?: Maybe<Scalars['uuid']>;
+  personWithAccessToken?: Maybe<Collection_ProgramPersonWithAccessToken_Obj_Rel_Insert_Input>;
   priority?: Maybe<Scalars['Int']>;
   roleName?: Maybe<Scalars['String']>;
 };
@@ -12019,11 +12229,13 @@ export type Content_ItemProgramPerson_On_Conflict = {
 export type Content_ItemProgramPerson_Order_By = {
   conference?: Maybe<Conference_Conference_Order_By>;
   conferenceId?: Maybe<Order_By>;
+  hasSubmissionRequestBeenSent?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   item?: Maybe<Content_Item_Order_By>;
   itemId?: Maybe<Order_By>;
   person?: Maybe<Collection_ProgramPerson_Order_By>;
   personId?: Maybe<Order_By>;
+  personWithAccessToken?: Maybe<Collection_ProgramPersonWithAccessToken_Order_By>;
   priority?: Maybe<Order_By>;
   roleName?: Maybe<Order_By>;
 };
@@ -12524,6 +12736,7 @@ export type Content_Item_Bool_Exp = {
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   elements?: Maybe<Content_Element_Bool_Exp>;
   events?: Maybe<Schedule_Event_Bool_Exp>;
+  hasUnsubmittedElements?: Maybe<Boolean_Comparison_Exp>;
   id?: Maybe<Uuid_Comparison_Exp>;
   itemExhibitions?: Maybe<Content_ItemExhibition_Bool_Exp>;
   itemPeople?: Maybe<Content_ItemProgramPerson_Bool_Exp>;
@@ -12655,6 +12868,7 @@ export type Content_Item_Order_By = {
   createdAt?: Maybe<Order_By>;
   elements_aggregate?: Maybe<Content_Element_Aggregate_Order_By>;
   events_aggregate?: Maybe<Schedule_Event_Aggregate_Order_By>;
+  hasUnsubmittedElements?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   itemExhibitions_aggregate?: Maybe<Content_ItemExhibition_Aggregate_Order_By>;
   itemPeople_aggregate?: Maybe<Content_ItemProgramPerson_Aggregate_Order_By>;
@@ -14517,11 +14731,14 @@ export type Job_Queues_SubmissionRequestEmailJob = {
   created_at: Scalars['timestamptz'];
   emailTemplate?: Maybe<Scalars['jsonb']>;
   id: Scalars['uuid'];
+  /** An object relationship */
+  person?: Maybe<Collection_ProgramPerson>;
+  personId?: Maybe<Scalars['uuid']>;
   processed: Scalars['Boolean'];
   updated_at: Scalars['timestamptz'];
   /** An object relationship */
-  uploader: Content_Uploader;
-  uploaderId: Scalars['uuid'];
+  uploader?: Maybe<Content_Uploader>;
+  uploaderId?: Maybe<Scalars['uuid']>;
 };
 
 
@@ -14565,6 +14782,8 @@ export type Job_Queues_SubmissionRequestEmailJob_Bool_Exp = {
   created_at?: Maybe<Timestamptz_Comparison_Exp>;
   emailTemplate?: Maybe<Jsonb_Comparison_Exp>;
   id?: Maybe<Uuid_Comparison_Exp>;
+  person?: Maybe<Collection_ProgramPerson_Bool_Exp>;
+  personId?: Maybe<Uuid_Comparison_Exp>;
   processed?: Maybe<Boolean_Comparison_Exp>;
   updated_at?: Maybe<Timestamptz_Comparison_Exp>;
   uploader?: Maybe<Content_Uploader_Bool_Exp>;
@@ -14597,6 +14816,8 @@ export type Job_Queues_SubmissionRequestEmailJob_Insert_Input = {
   created_at?: Maybe<Scalars['timestamptz']>;
   emailTemplate?: Maybe<Scalars['jsonb']>;
   id?: Maybe<Scalars['uuid']>;
+  person?: Maybe<Collection_ProgramPerson_Obj_Rel_Insert_Input>;
+  personId?: Maybe<Scalars['uuid']>;
   processed?: Maybe<Scalars['Boolean']>;
   updated_at?: Maybe<Scalars['timestamptz']>;
   uploader?: Maybe<Content_Uploader_Obj_Rel_Insert_Input>;
@@ -14608,6 +14829,7 @@ export type Job_Queues_SubmissionRequestEmailJob_Max_Fields = {
   __typename?: 'job_queues_SubmissionRequestEmailJob_max_fields';
   created_at?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['uuid']>;
+  personId?: Maybe<Scalars['uuid']>;
   updated_at?: Maybe<Scalars['timestamptz']>;
   uploaderId?: Maybe<Scalars['uuid']>;
 };
@@ -14617,6 +14839,7 @@ export type Job_Queues_SubmissionRequestEmailJob_Min_Fields = {
   __typename?: 'job_queues_SubmissionRequestEmailJob_min_fields';
   created_at?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['uuid']>;
+  personId?: Maybe<Scalars['uuid']>;
   updated_at?: Maybe<Scalars['timestamptz']>;
   uploaderId?: Maybe<Scalars['uuid']>;
 };
@@ -14642,6 +14865,8 @@ export type Job_Queues_SubmissionRequestEmailJob_Order_By = {
   created_at?: Maybe<Order_By>;
   emailTemplate?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
+  person?: Maybe<Collection_ProgramPerson_Order_By>;
+  personId?: Maybe<Order_By>;
   processed?: Maybe<Order_By>;
   updated_at?: Maybe<Order_By>;
   uploader?: Maybe<Content_Uploader_Order_By>;
@@ -14667,6 +14892,8 @@ export enum Job_Queues_SubmissionRequestEmailJob_Select_Column {
   /** column name */
   Id = 'id',
   /** column name */
+  PersonId = 'personId',
+  /** column name */
   Processed = 'processed',
   /** column name */
   UpdatedAt = 'updated_at',
@@ -14679,6 +14906,7 @@ export type Job_Queues_SubmissionRequestEmailJob_Set_Input = {
   created_at?: Maybe<Scalars['timestamptz']>;
   emailTemplate?: Maybe<Scalars['jsonb']>;
   id?: Maybe<Scalars['uuid']>;
+  personId?: Maybe<Scalars['uuid']>;
   processed?: Maybe<Scalars['Boolean']>;
   updated_at?: Maybe<Scalars['timestamptz']>;
   uploaderId?: Maybe<Scalars['uuid']>;
@@ -14692,6 +14920,8 @@ export enum Job_Queues_SubmissionRequestEmailJob_Update_Column {
   EmailTemplate = 'emailTemplate',
   /** column name */
   Id = 'id',
+  /** column name */
+  PersonId = 'personId',
   /** column name */
   Processed = 'processed',
   /** column name */
@@ -18921,6 +19151,7 @@ export type Mutation_RootUpdate_Collection_Exhibition_By_PkArgs = {
 
 /** mutation root */
 export type Mutation_RootUpdate_Collection_ProgramPersonArgs = {
+  _inc?: Maybe<Collection_ProgramPerson_Inc_Input>;
   _set?: Maybe<Collection_ProgramPerson_Set_Input>;
   where: Collection_ProgramPerson_Bool_Exp;
 };
@@ -18935,6 +19166,7 @@ export type Mutation_RootUpdate_Collection_ProgramPersonByAccessTokenArgs = {
 
 /** mutation root */
 export type Mutation_RootUpdate_Collection_ProgramPersonWithAccessTokenArgs = {
+  _inc?: Maybe<Collection_ProgramPersonWithAccessToken_Inc_Input>;
   _set?: Maybe<Collection_ProgramPersonWithAccessToken_Set_Input>;
   where: Collection_ProgramPersonWithAccessToken_Bool_Exp;
 };
@@ -18942,6 +19174,7 @@ export type Mutation_RootUpdate_Collection_ProgramPersonWithAccessTokenArgs = {
 
 /** mutation root */
 export type Mutation_RootUpdate_Collection_ProgramPerson_By_PkArgs = {
+  _inc?: Maybe<Collection_ProgramPerson_Inc_Input>;
   _set?: Maybe<Collection_ProgramPerson_Set_Input>;
   pk_columns: Collection_ProgramPerson_Pk_Columns_Input;
 };
@@ -37408,15 +37641,16 @@ export type UploaderPartsFragment = { __typename?: 'content_Uploader', id: any, 
 
 export type InsertSubmissionRequestEmailsMutationVariables = Exact<{
   uploaderIds: Array<Scalars['uuid']> | Scalars['uuid'];
+  personIds: Array<Scalars['uuid']> | Scalars['uuid'];
 }>;
 
 
-export type InsertSubmissionRequestEmailsMutation = { __typename?: 'mutation_root', update_content_Uploader?: Maybe<{ __typename?: 'content_Uploader_mutation_response', affected_rows: number }> };
+export type InsertSubmissionRequestEmailsMutation = { __typename?: 'mutation_root', update_content_Uploader?: Maybe<{ __typename?: 'content_Uploader_mutation_response', affected_rows: number }>, update_collection_ProgramPerson?: Maybe<{ __typename?: 'collection_ProgramPerson_mutation_response', affected_rows: number }> };
 
 export type MarkAndSelectUnprocessedSubmissionRequestEmailJobsMutationVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MarkAndSelectUnprocessedSubmissionRequestEmailJobsMutation = { __typename?: 'mutation_root', update_job_queues_SubmissionRequestEmailJob?: Maybe<{ __typename?: 'job_queues_SubmissionRequestEmailJob_mutation_response', returning: Array<{ __typename?: 'job_queues_SubmissionRequestEmailJob', id: any, emailTemplate?: Maybe<any>, uploader: { __typename?: 'content_Uploader', id: any, email: string, emailsSentCount: number, name: string, conference: { __typename?: 'conference_Conference', id: any, name: string, shortName: string }, element: { __typename?: 'content_Element', id: any, typeName: Content_ElementType_Enum, accessToken: string, name: string, uploadsRemaining?: Maybe<number>, isHidden: boolean, data: any, conference: { __typename?: 'conference_Conference', id: any, name: string }, item: { __typename?: 'content_Item', id: any, title: string }, permissionGrants: Array<{ __typename?: 'content_ElementPermissionGrant', id: any, permissionSetId: any, groupId?: Maybe<any>, entityId?: Maybe<any>, conferenceSlug: string }> } } }> }> };
+export type MarkAndSelectUnprocessedSubmissionRequestEmailJobsMutation = { __typename?: 'mutation_root', update_job_queues_SubmissionRequestEmailJob?: Maybe<{ __typename?: 'job_queues_SubmissionRequestEmailJob_mutation_response', returning: Array<{ __typename?: 'job_queues_SubmissionRequestEmailJob', id: any, emailTemplate?: Maybe<any>, uploader?: Maybe<{ __typename?: 'content_Uploader', id: any, email: string, emailsSentCount: number, name: string, conference: { __typename?: 'conference_Conference', id: any, name: string, shortName: string }, element: { __typename?: 'content_Element', id: any, typeName: Content_ElementType_Enum, accessToken: string, name: string, uploadsRemaining?: Maybe<number>, isHidden: boolean, data: any, conference: { __typename?: 'conference_Conference', id: any, name: string }, item: { __typename?: 'content_Item', id: any, title: string }, permissionGrants: Array<{ __typename?: 'content_ElementPermissionGrant', id: any, permissionSetId: any, groupId?: Maybe<any>, entityId?: Maybe<any>, conferenceSlug: string }> } }>, person?: Maybe<{ __typename?: 'collection_ProgramPerson', id: any, name: string, email?: Maybe<string>, accessToken: string, conference: { __typename?: 'conference_Conference', id: any, name: string, shortName: string } }> }> }> };
 
 export type UnmarkSubmissionRequestEmailJobsMutationVariables = Exact<{
   ids: Array<Scalars['uuid']> | Scalars['uuid'];
@@ -37901,8 +38135,8 @@ export const SetShuffleRoomsEndedDocument = {"kind":"Document","definitions":[{"
 export const UploadableElementDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"UploadableElement"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"accessToken"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content_Element"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"accessToken"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"Variable","name":{"kind":"Name","value":"accessToken"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"UploadableElementFields"}},{"kind":"Field","name":{"kind":"Name","value":"conference"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"configurations"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"key"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"EnumValue","value":"UPLOAD_CUTOFF_TIMESTAMP"}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"conferenceId"}},{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"value"}}]}}]}}]}}]}},...UploadableElementFieldsFragmentDoc.definitions]} as unknown as DocumentNode<UploadableElementQuery, UploadableElementQueryVariables>;
 export const GetUploadersDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetUploaders"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"elementId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"content_Uploader"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"elementId"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"Variable","name":{"kind":"Name","value":"elementId"}}}]}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"conferenceId"}}]}}]}}]} as unknown as DocumentNode<GetUploadersQuery, GetUploadersQueryVariables>;
 export const SetUploadableElementUploadsRemainingDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"SetUploadableElementUploadsRemaining"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"uploadsRemaining"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"Int"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"update_content_Element_by_pk"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"pk_columns"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}]}},{"kind":"Argument","name":{"kind":"Name","value":"_set"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"uploadsRemaining"},"value":{"kind":"Variable","name":{"kind":"Name","value":"uploadsRemaining"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<SetUploadableElementUploadsRemainingMutation, SetUploadableElementUploadsRemainingMutationVariables>;
-export const InsertSubmissionRequestEmailsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"InsertSubmissionRequestEmails"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"uploaderIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"update_content_Uploader"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"id"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_in"},"value":{"kind":"Variable","name":{"kind":"Name","value":"uploaderIds"}}}]}}]}},{"kind":"Argument","name":{"kind":"Name","value":"_inc"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"emailsSentCount"},"value":{"kind":"IntValue","value":"1"}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"affected_rows"}}]}}]}}]} as unknown as DocumentNode<InsertSubmissionRequestEmailsMutation, InsertSubmissionRequestEmailsMutationVariables>;
-export const MarkAndSelectUnprocessedSubmissionRequestEmailJobsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"MarkAndSelectUnprocessedSubmissionRequestEmailJobs"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"update_job_queues_SubmissionRequestEmailJob"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"processed"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"BooleanValue","value":false}}]}}]}},{"kind":"Argument","name":{"kind":"Name","value":"_set"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"processed"},"value":{"kind":"BooleanValue","value":true}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"returning"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"emailTemplate"}},{"kind":"Field","name":{"kind":"Name","value":"uploader"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"UploaderParts"}}]}}]}}]}}]}},...UploaderPartsFragmentDoc.definitions]} as unknown as DocumentNode<MarkAndSelectUnprocessedSubmissionRequestEmailJobsMutation, MarkAndSelectUnprocessedSubmissionRequestEmailJobsMutationVariables>;
+export const InsertSubmissionRequestEmailsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"InsertSubmissionRequestEmails"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"uploaderIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}}}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"personIds"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"update_content_Uploader"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"id"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_in"},"value":{"kind":"Variable","name":{"kind":"Name","value":"uploaderIds"}}}]}}]}},{"kind":"Argument","name":{"kind":"Name","value":"_inc"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"emailsSentCount"},"value":{"kind":"IntValue","value":"1"}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"affected_rows"}}]}},{"kind":"Field","name":{"kind":"Name","value":"update_collection_ProgramPerson"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"id"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_in"},"value":{"kind":"Variable","name":{"kind":"Name","value":"personIds"}}}]}}]}},{"kind":"Argument","name":{"kind":"Name","value":"_inc"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"submissionRequestsSentCount"},"value":{"kind":"IntValue","value":"1"}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"affected_rows"}}]}}]}}]} as unknown as DocumentNode<InsertSubmissionRequestEmailsMutation, InsertSubmissionRequestEmailsMutationVariables>;
+export const MarkAndSelectUnprocessedSubmissionRequestEmailJobsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"MarkAndSelectUnprocessedSubmissionRequestEmailJobs"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"update_job_queues_SubmissionRequestEmailJob"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"processed"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"BooleanValue","value":false}}]}}]}},{"kind":"Argument","name":{"kind":"Name","value":"_set"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"processed"},"value":{"kind":"BooleanValue","value":true}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"returning"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"emailTemplate"}},{"kind":"Field","name":{"kind":"Name","value":"uploader"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"UploaderParts"}}]}},{"kind":"Field","name":{"kind":"Name","value":"person"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"email"}},{"kind":"Field","name":{"kind":"Name","value":"accessToken"}},{"kind":"Field","name":{"kind":"Name","value":"conference"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"shortName"}}]}}]}}]}}]}}]}},...UploaderPartsFragmentDoc.definitions]} as unknown as DocumentNode<MarkAndSelectUnprocessedSubmissionRequestEmailJobsMutation, MarkAndSelectUnprocessedSubmissionRequestEmailJobsMutationVariables>;
 export const UnmarkSubmissionRequestEmailJobsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UnmarkSubmissionRequestEmailJobs"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"ids"}},"type":{"kind":"NonNullType","type":{"kind":"ListType","type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}}}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"update_job_queues_SubmissionRequestEmailJob"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"id"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_in"},"value":{"kind":"Variable","name":{"kind":"Name","value":"ids"}}}]}}]}},{"kind":"Argument","name":{"kind":"Name","value":"_set"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"processed"},"value":{"kind":"BooleanValue","value":false}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"affected_rows"}}]}}]}}]} as unknown as DocumentNode<UnmarkSubmissionRequestEmailJobsMutation, UnmarkSubmissionRequestEmailJobsMutationVariables>;
 export const GetElementIdForVideoRenderJobDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetElementIdForVideoRenderJob"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"videoRenderJobId"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"uuid"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"video_VideoRenderJob_by_pk"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"videoRenderJobId"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"elementId"}},{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<GetElementIdForVideoRenderJobQuery, GetElementIdForVideoRenderJobQueryVariables>;
 export const SelectNewVideoRenderJobsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"SelectNewVideoRenderJobs"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"video_VideoRenderJob"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"limit"},"value":{"kind":"IntValue","value":"10"}},{"kind":"Argument","name":{"kind":"Name","value":"where"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"jobStatusName"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"_eq"},"value":{"kind":"EnumValue","value":"NEW"}}]}}]}},{"kind":"Argument","name":{"kind":"Name","value":"order_by"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"created_at"},"value":{"kind":"EnumValue","value":"asc"}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<SelectNewVideoRenderJobsQuery, SelectNewVideoRenderJobsQueryVariables>;

--- a/services/actions/src/handlers/email.ts
+++ b/services/actions/src/handlers/email.ts
@@ -215,9 +215,18 @@ async function initSGMail(): Promise<
             const response = await apolloClient.query({
                 query: GetSendGridConfigDocument,
             });
-            assert(response.data.apiKey, "SendGrid API not configured");
-            assert(response.data.senderEmail, "SendGrid Sender not configured");
-            assert(response.data.replyTo, "SendGrid Reply-To not configured");
+            if (!response.data.apiKey) {
+                console.error("Unable to initialise SendGrid email. SendGrid API Key not configured");
+                return false;
+            }
+            if (!response.data.senderEmail) {
+                console.error("Unable to initialise SendGrid email. SendGrid Sender not configured");
+                return false;
+            }
+            if (!response.data.replyTo) {
+                console.error("Unable to initialise SendGrid email. SendGrid Reply-To not configured");
+                return false;
+            }
 
             sgMail.setApiKey(response.data.apiKey.value);
             sgMailInitialised = {

--- a/services/actions/src/lib/conferenceConfiguration.ts
+++ b/services/actions/src/lib/conferenceConfiguration.ts
@@ -24,8 +24,12 @@ export async function getConferenceConfiguration<T = any>(
         },
     });
 
-    if (result.data?.conference_Configuration_by_pk && is<T>(result.data.conference_Configuration_by_pk)) {
-        return result.data.conference_Configuration_by_pk;
+    if (
+        result.data?.conference_Configuration_by_pk?.value !== undefined &&
+        result.data?.conference_Configuration_by_pk?.value !== null &&
+        is<T>(result.data.conference_Configuration_by_pk.value)
+    ) {
+        return result.data.conference_Configuration_by_pk.value;
     } else {
         return null;
     }

--- a/shared/src/email.ts
+++ b/shared/src/email.ts
@@ -8,8 +8,8 @@ export type EmailTemplate_Defaults = {
  * The default template for the subtitles generated email.
  */
 export const EMAIL_TEMPLATE_SUBTITLES_GENERATED: EmailTemplate_Defaults = {
-    htmlBodyTemplate: `<p>Dear {{{uploader.name}}},</p>
-<p>We have automatically generated subtitles for your item <em>{{{file.name}}}</em> ({{{item.title}}}) at {{{conference.name}}}.</p>
+    htmlBodyTemplate: `<p>Dear {{{person.name}}},</p>
+<p>We have automatically generated subtitles for your content <em>{{{file.name}}}</em> ({{{item.title}}}) at {{{conference.name}}}.</p>
 <p>Automated subtitles aren't always accurate, so you can <a href="{{{uploadLink}}}">review and edit them here</a>.</p>
 <p>Thank you,<br/>
 The Midspace team
@@ -41,15 +41,14 @@ export interface EmailView_SubtitlesGenerated {
  * The default template for the submission request email.
  */
 export const EMAIL_TEMPLATE_SUBMISSION_REQUEST: EmailTemplate_Defaults = {
-    htmlBodyTemplate: `<p>Dear {{{uploader.name}}},</p>
+    htmlBodyTemplate: `<p>Dear {{{person.name}}},</p>
 <p>
     The organisers of {{{conference.name}}} are requesting that you or
-    your co-authors/co-presenters upload the following file: {{{file.name}}} for
-    "{{{item.title}}}".
+    your co-authors/co-presenters submit your content to Midspace.
 </p>
 <p>
     Please do not forward or share this email: anyone with the link contained
-    herein can use it to upload content to your conference item.
+    herein can use it to modify your submissions.
 </p>
 <p>
     Please <a href="{{{uploadLink}}}">submit your content on this page</a> by 23:59 UTC on DD MMMM.
@@ -66,21 +65,24 @@ export const EMAIL_TEMPLATE_SUBMISSION_REQUEST: EmailTemplate_Defaults = {
 <p>We hope you enjoy your conference,<br/>
 The Midspace team
 </p>`,
-    subjectTemplate: "{{{conference.shortName}}}: Submit your {{{file.name}}} for {{{item.title}}}",
+    subjectTemplate: "Submissions for {{{conference.shortName}}}",
 };
 
 /**
  * The view available when rendering the submission request email. Default template is {@link EMAIL_TEMPLATE_SUBMISSION_REQUEST}.
  */
 export interface EmailView_SubmissionRequest {
-    uploader: {
+    person?: {
         name: string;
     };
-    file: {
+    uploader?: {
+        name: string;
+    };
+    file?: {
         name: string;
         typeName: string;
     };
-    item: {
+    item?: {
         title: string;
     };
     conference: {


### PR DESCRIPTION
## What's improved

This is part 2 of unifying uploaders with item people. The backends changes here are fully backwards compatible, while the frontend changes remove the old Uploaders-based UI elements and replace them with ones focused on Item People.

## Upgrading

Instructions for other developers on how to upgrade their environment after
pulling this new code. Please tick (i.e. put an 'x' in) the boxes for the
actions that are necessary.

- [x] Run GraphQL Codegen in the frontend and actions service.
- [x] Apply Hasura migrations
- [x] Apply Hasura metadata

## Deployment

Instructions for how to deploy these changes to production. Please tick (i.e.
put an 'x' in) the boxes for the actions that are necessary.

- [x] Apply migrations to Hasura
- [x] Apply metadata to Hasura
- [x] Re-deploy frontend
- [x] Re-deploy actions service
