### PR TITLE
📦 Use Hasura CLI npm package, don't start it until endpoint available

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,7 +27,7 @@
             "type": "shell",
             "dependsOn": "Start Docker Services -- Local Development",
             "isBackground": true,
-            "command": "hasura",
+            "command": "npm",
             "problemMatcher": [],
             "options": {
                 "cwd": "${workspaceFolder}/hasura"
@@ -35,14 +35,14 @@
             "runOptions": {
                 "instanceLimit": 1
             },
-            "args": ["console", "--envfile", ".env.local"]
+            "args": ["run", "hasura:console-when-ready", "--envfile='./.env.local'"]
         },
         // Hasura Console -- CI Testing
         {
             "label": "Hasura Console -- CI Testing",
             "type": "shell",
             "isBackground": true,
-            "command": "hasura",
+            "command": "npm",
             "problemMatcher": [],
             "options": {
                 "cwd": "${workspaceFolder}/hasura"
@@ -50,7 +50,7 @@
             "runOptions": {
                 "instanceLimit": 1
             },
-            "args": ["console", "--envfile", ".env.ci-test"]
+            "args": ["run", "hasura:console-when-ready", "--envfile='./.env.ci-test'"]
         },
         // Action service -- Local Development
         {

--- a/hasura/README.md
+++ b/hasura/README.md
@@ -6,8 +6,6 @@ and all of our backend services.
 ## Pre-requisites
 
 1. [Docker Compose](https://docs.docker.com/compose/)
-1. [Hasura CLI](https://hasura.io/docs/2.0/graphql/core/hasura-cli/install-hasura-cli.html)
-   - At the time of writing, the Hasura CLI installer defaults to installing `v1.3.3`. You will need a version of the CLI that matches the version of the Hasura image you are using in your `docker-compose.yaml`. You can run (for example) `hasura update-cli --version 2.0.1` to update the CLI to `v2.0.1`.
 
 ## Setting Up
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "clowdr",
             "version": "1.0.0",
             "license": "BSD-3-Clause",
             "workspaces": [
@@ -18,11 +19,13 @@
                 "eslint-plugin-jest": "^24.3.6",
                 "eslint-plugin-react": "^7.24.0",
                 "eslint-plugin-react-hooks": "^4.2.0",
+                "hasura-cli": "^2.0.9",
                 "husky": "^7.0.0",
                 "lint-staged": "^11.1.1",
                 "prettier": "^2.3.2",
                 "prettier-plugin-organize-imports": "^2.2.0",
-                "typescript": "^4.3.5"
+                "typescript": "^4.3.5",
+                "wait-on": "^6.0.0"
             },
             "engines": {
                 "node": "16.x",
@@ -141,6 +144,21 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
+        "node_modules/@hapi/hoek": {
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+            "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
+            "dev": true
+        },
+        "node_modules/@hapi/topo": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+            "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+            "dev": true,
+            "dependencies": {
+                "@hapi/hoek": "^9.0.0"
+            }
+        },
         "node_modules/@jest/types": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
@@ -191,6 +209,27 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@sideway/address": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+            "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+            "dev": true,
+            "dependencies": {
+                "@hapi/hoek": "^9.0.0"
+            }
+        },
+        "node_modules/@sideway/formula": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+            "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+            "dev": true
+        },
+        "node_modules/@sideway/pinpoint": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+            "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+            "dev": true
         },
         "node_modules/@types/istanbul-lib-coverage": {
             "version": "2.0.3",
@@ -606,6 +645,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/axios": {
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "dev": true,
+            "dependencies": {
+                "follow-redirects": "^1.14.0"
             }
         },
         "node_modules/balanced-match": {
@@ -1376,6 +1424,26 @@
             "integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
             "dev": true
         },
+        "node_modules/follow-redirects": {
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1552,6 +1620,85 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasura-cli": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/hasura-cli/-/hasura-cli-2.0.9.tgz",
+            "integrity": "sha512-95xAxNFfF1nntncULGKGQ9UEbhEWsgcMHdqOLsreq9E1emh2CVu1xuY/WezGMaCe1D4ZII7HxSQZBIhdnF9vKg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "dependencies": {
+                "axios": "^0.21.1",
+                "chalk": "^2.4.2"
+            },
+            "bin": {
+                "hasura": "hasura"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/hasura-cli/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/hasura-cli/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/hasura-cli/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/hasura-cli/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "node_modules/hasura-cli/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/hasura-cli/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/human-signals": {
@@ -1882,6 +2029,19 @@
                 "node": ">= 10.14.2"
             }
         },
+        "node_modules/joi": {
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+            "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+            "dev": true,
+            "dependencies": {
+                "@hapi/hoek": "^9.0.0",
+                "@hapi/topo": "^5.0.0",
+                "@sideway/address": "^4.1.0",
+                "@sideway/formula": "^3.0.0",
+                "@sideway/pinpoint": "^2.0.0"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2013,6 +2173,12 @@
             "peerDependencies": {
                 "enquirer": ">= 2.3.0 < 3"
             }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
@@ -2175,6 +2341,12 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
         },
         "node_modules/ms": {
             "version": "2.1.2",
@@ -3159,6 +3331,40 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/wait-on": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.0.tgz",
+            "integrity": "sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==",
+            "dev": true,
+            "dependencies": {
+                "axios": "^0.21.1",
+                "joi": "^17.4.0",
+                "lodash": "^4.17.21",
+                "minimist": "^1.2.5",
+                "rxjs": "^7.1.0"
+            },
+            "bin": {
+                "wait-on": "bin/wait-on"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/wait-on/node_modules/rxjs": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+            "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "~2.1.0"
+            }
+        },
+        "node_modules/wait-on/node_modules/tslib": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+            "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+            "dev": true
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3375,6 +3581,21 @@
                 "strip-json-comments": "^3.1.1"
             }
         },
+        "@hapi/hoek": {
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+            "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
+            "dev": true
+        },
+        "@hapi/topo": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+            "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "^9.0.0"
+            }
+        },
         "@jest/types": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
@@ -3413,6 +3634,27 @@
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
             }
+        },
+        "@sideway/address": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+            "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "^9.0.0"
+            }
+        },
+        "@sideway/formula": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+            "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+            "dev": true
+        },
+        "@sideway/pinpoint": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+            "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+            "dev": true
         },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.3",
@@ -3703,6 +3945,15 @@
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true
+        },
+        "axios": {
+            "version": "0.21.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+            "dev": true,
+            "requires": {
+                "follow-redirects": "^1.14.0"
+            }
         },
         "balanced-match": {
             "version": "1.0.2",
@@ -4304,6 +4555,12 @@
             "integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+            "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+            "dev": true
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4431,6 +4688,68 @@
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
             "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
             "dev": true
+        },
+        "hasura-cli": {
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/hasura-cli/-/hasura-cli-2.0.9.tgz",
+            "integrity": "sha512-95xAxNFfF1nntncULGKGQ9UEbhEWsgcMHdqOLsreq9E1emh2CVu1xuY/WezGMaCe1D4ZII7HxSQZBIhdnF9vKg==",
+            "dev": true,
+            "requires": {
+                "axios": "^0.21.1",
+                "chalk": "^2.4.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
         },
         "human-signals": {
             "version": "2.1.0",
@@ -4652,6 +4971,19 @@
             "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
             "dev": true
         },
+        "joi": {
+            "version": "17.4.2",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+            "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+            "dev": true,
+            "requires": {
+                "@hapi/hoek": "^9.0.0",
+                "@hapi/topo": "^5.0.0",
+                "@sideway/address": "^4.1.0",
+                "@sideway/formula": "^3.0.0",
+                "@sideway/pinpoint": "^2.0.0"
+            }
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4759,6 +5091,12 @@
                 "through": "^2.3.8",
                 "wrap-ansi": "^7.0.0"
             }
+        },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "lodash.clonedeep": {
             "version": "4.5.0",
@@ -4884,6 +5222,12 @@
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
+        },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
         },
         "ms": {
             "version": "2.1.2",
@@ -5593,6 +5937,36 @@
             "version": "13.6.0",
             "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
             "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
+        },
+        "wait-on": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.0.tgz",
+            "integrity": "sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==",
+            "dev": true,
+            "requires": {
+                "axios": "^0.21.1",
+                "joi": "^17.4.0",
+                "lodash": "^4.17.21",
+                "minimist": "^1.2.5",
+                "rxjs": "^7.1.0"
+            },
+            "dependencies": {
+                "rxjs": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+                    "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "~2.1.0"
+                    }
+                },
+                "tslib": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+                    "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+                    "dev": true
+                }
+            }
         },
         "which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "run-services-realtime": "npx foreman start --procfile ./Realtime.Procfile -p 3002",
         "run-services-playout": "npx foreman start --procfile ./Playout.Procfile -p 3003",
         "lint-staged": "lint-staged",
-        "prepare": "node ./prepare.js"
+        "prepare": "node ./prepare.js",
+        "hasura:console-when-ready": "cd hasura && wait-on http-get://localhost:8080/v1/version && hasura console --envfile $npm_config_envfile"
     },
     "repository": {
         "type": "git",
@@ -29,11 +30,13 @@
         "eslint-plugin-jest": "^24.3.6",
         "eslint-plugin-react": "^7.24.0",
         "eslint-plugin-react-hooks": "^4.2.0",
+        "hasura-cli": "^2.0.9",
         "husky": "^7.0.0",
         "lint-staged": "^11.1.1",
         "prettier": "^2.3.2",
         "prettier-plugin-organize-imports": "^2.2.0",
-        "typescript": "^4.3.5"
+        "typescript": "^4.3.5",
+        "wait-on": "^6.0.0"
     },
     "lint-staged": {
         "*.js": "eslint --cache --fix",


### PR DESCRIPTION
Please ensure your PR title includes the relevant emoji signifiers. See
[CONTRIBUTING] for details.

## What's improved

- Instead of requiring the user to install Hasura CLI manually, just pull in the npm package
- When starting Hasura CLI from the VS Code task, wait for the graphql-engine endpoints to become functional

## Details

- Related issue: #[Insert issue number]

## Upgrading

Instructions for other developers on how to upgrade their environment after
pulling this new code. Please tick (i.e. put an 'x' in) the boxes for the
actions that are necessary.

- [ ] Run GraphQL Codegen in the [frontend/actions service/playout service/realtime service]
- [x] Re-install NPM packages in `./`
- [ ] Apply Hasura migrations
- [ ] Apply Hasura metadata
- [ ] Update Auth0 rules
- [ ] Update environment variables
- [ ] Re-deploy AWS CDK [and update AWS environment variables]

## Deployment

Instructions for how to deploy these changes to production. Please tick (i.e.
put an 'x' in) the boxes for the actions that are necessary.

- [ ] Apply migrations to Hasura
- [ ] Apply metadata to Hasura
- [ ] Reload enum table/values in Hasura for [table names]
- [ ] Re-deploy frontend
- [ ] Re-deploy actions service
- [ ] Re-deploy playout service
- [ ] Re-deploy real-time service
- [ ] Flush real-time service state (Redis/RabbitMQ)
- [ ] Update environment variables for [name of component]

Any other steps necessary to re-deploy?
