### PR TITLE
Fix checklist item that checks whether broadcast videos have been uploaded

### DIFF
--- a/frontend/src/aspects/Conference/Manage/Checklist/ChecklistPage.tsx
+++ b/frontend/src/aspects/Conference/Manage/Checklist/ChecklistPage.tsx
@@ -870,7 +870,7 @@ export default function ChecklistPage(): JSX.Element {
         );
         return (
             <ChecklistItem
-                title="All pre-recorded events with a broadcast video element have had a video uploaded"
+                title="All pre-recorded events whose items have a broadcast video element have had a video uploaded"
                 status="error"
                 description="Pre-recorded events pick up the Broadcast Video from their assigned content item. One or more 'pre-recorded' mode events has been assigned an item which has a broadcast video element for which a file has not been uploaded. This means the event will not be able to play back a video. This may be caused by a missing video submission. Please review your schedule and content to upload the missing video(s) or remove the events from the schedule."
                 action={{


### PR DESCRIPTION
## What's [new / improved / fixed]

- Fix the logic and title of the checklist item that is intended to check whether extant broadcast video elements actually have a video uploaded to them.

## Details

- Related issue: #[Insert issue number]

## Upgrading

Instructions for other developers on how to upgrade their environment after
pulling this new code. Please tick (i.e. put an 'x' in) the boxes for the
actions that are necessary.

- [ ] Run GraphQL Codegen in the [frontend/actions service/playout service/realtime service]
- [ ] Re-install NPM packages in [insert name of folder]
- [ ] Apply Hasura migrations
- [ ] Apply Hasura metadata
- [ ] Update Auth0 rules
- [ ] Update environment variables
- [ ] Re-deploy AWS CDK [and update AWS environment variables]

## Deployment

Instructions for how to deploy these changes to production. Please tick (i.e.
put an 'x' in) the boxes for the actions that are necessary.

- [ ] Apply migrations to Hasura
- [ ] Apply metadata to Hasura
- [ ] Reload enum table/values in Hasura for [table names]
- [x] Re-deploy frontend
- [ ] Re-deploy actions service
- [ ] Re-deploy playout service
- [ ] Re-deploy real-time service
- [ ] Flush real-time service state (Redis/RabbitMQ)
- [ ] Update environment variables for [name of component]

Any other steps necessary to re-deploy?
